### PR TITLE
Add adapter generation demo scripts

### DIFF
--- a/tutorials/scripts/run_adapter_generation.py
+++ b/tutorials/scripts/run_adapter_generation.py
@@ -2,31 +2,25 @@
 # SPDX-License-Identifier: Apache-2.0
 """Granite Switch Adapter Generation Demo (HuggingFace transformers).
 
-Composes a Granite Switch model with the RAG, core, and guardian
-adapter libraries, then runs one demo per adapter and saves the results
-to a JSON file.
+Loads the open-source Granite Switch model and runs one demo per
+embedded adapter, saving the results to a JSON file.
 
 Each adapter has a dedicated ``demo_<adapter>`` function that owns its
-demo inputs and the message/document layout the adapter expects. The
-layouts mirror Mellea's intrinsic wrappers (one-to-one with the
-``rewrite_question`` / ``check_answerability`` / ``guardian_check`` /
-... functions in ``mellea.stdlib.components.intrinsic``). Adapters are
-activated by passing ``adapter_name=...`` to
+demo inputs and the message/document layout the adapter expects.
+Adapters are activated by passing ``adapter_name=...`` to
 ``tokenizer.apply_chat_template``, following the granite-switch README.
 
 Usage:
     python run_adapter_generation.py [--output results.json] [--max-tokens 1024]
-    python run_adapter_generation.py --model-dir /path/to/composed/model
+    python run_adapter_generation.py --model-dir /path/to/model
 
-Requires: CUDA GPU, granite-switch[hf,compose] installed.
+Requires: CUDA GPU, granite-switch[hf] installed.
 """
 
 import argparse
 import json
 import re
-import subprocess
 import sys
-import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Callable, Optional
@@ -37,75 +31,31 @@ import torch
 # Configuration
 # ---------------------------------------------------------------------------
 
-DEFAULT_BASE_MODEL = "ibm-granite/granite-4.1-3b"
-
-LIBRARIES = [
-    "ibm-granite/granitelib-rag-r1.0",
-    "ibm-granite/granitelib-core-r1.0",
-    "ibm-granite/granitelib-guardian-r1.0",
-]
-
-BUILD_TIMEOUT = 3600  # 60 minutes for compose
+DEFAULT_MODEL = "ibm-granite/granite-switch-4.1-3b-preview"
 
 
 # ---------------------------------------------------------------------------
-# Compose / load / generate helpers
+# Load / generate helpers
 # ---------------------------------------------------------------------------
 
 
-def compose_model(output_dir: Path, base_model: str) -> Path:
-    """Compose a model with all adapter libraries."""
-    cmd = [
-        sys.executable,
-        "-m",
-        "granite_switch.composer.compose_granite_switch",
-        "--base-model",
-        base_model,
-        "--adapters",
-        *LIBRARIES,
-        "--output",
-        str(output_dir),
-    ]
-
-    print(f"Base model: {base_model}")
-    print(f"Composing model with libraries: {', '.join(LIBRARIES)}")
-    print(f"Output directory: {output_dir}")
-    print("This may take several minutes...")
-    print()
-
-    result = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        timeout=BUILD_TIMEOUT,
-    )
-
-    if result.returncode != 0:
-        print("Compose failed!")
-        print(result.stderr[-3000:] if result.stderr else result.stdout[-3000:])
-        sys.exit(1)
-
-    print("Compose completed successfully.")
-    return output_dir
-
-
-def load_model(model_dir: Path):
-    """Load the composed model and tokenizer."""
+def load_model(model_dir: str):
+    """Load the Granite Switch model and tokenizer."""
     # Registers the GraniteSwitch architecture with transformers'
     # AutoConfig / AutoModel. Must be imported before from_pretrained.
     import granite_switch.hf  # noqa: F401
 
-    from transformers import AutoModelForCausalLM, AutoTokenizer
+    from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
     print(f"Loading model from {model_dir}...")
 
-    tokenizer = AutoTokenizer.from_pretrained(str(model_dir), fix_mistral_regex=True)
-    model = AutoModelForCausalLM.from_pretrained(str(model_dir), trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(model_dir, fix_mistral_regex=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_dir, trust_remote_code=True, device_map="auto"
+    )
     model.eval()
-    model.to("cuda")
 
-    with open(model_dir / "config.json") as f:
-        config = json.load(f)
+    config = AutoConfig.from_pretrained(model_dir, trust_remote_code=True).to_dict()
 
     print(f"Loaded model with {len(config.get('adapter_names', []))} adapters")
     return model, tokenizer, config
@@ -982,14 +932,13 @@ def run_adapter_generation(
 
 def save_results(
     results: dict, config: dict, output_path: Path,
-    max_new_tokens: int, base_model: str,
+    max_new_tokens: int, model_dir: str,
 ):
     """Save results to JSON file."""
     output = {
         "metadata": {
             "timestamp": datetime.now().isoformat(),
-            "base_model": base_model,
-            "libraries": LIBRARIES,
+            "model": model_dir,
             "max_new_tokens": max_new_tokens,
             "num_adapters": len(config.get("adapter_names", [])),
             "adapter_names": config.get("adapter_names", []),
@@ -1027,12 +976,11 @@ def main():
         ),
     )
     parser.add_argument(
-        "--model-dir", type=str, default=None,
-        help="Path to pre-composed model (skips compose step)",
-    )
-    parser.add_argument(
-        "--base-model", type=str, default=DEFAULT_BASE_MODEL,
-        help=f"Base model for compose (default: {DEFAULT_BASE_MODEL})",
+        "--model-dir", type=str, default=DEFAULT_MODEL,
+        help=(
+            f"Model repo id or local path "
+            f"(default: {DEFAULT_MODEL})"
+        ),
     )
     args = parser.parse_args()
 
@@ -1045,18 +993,7 @@ def main():
     print("=" * 60)
     print()
 
-    if args.model_dir:
-        model_dir = Path(args.model_dir)
-        if not model_dir.exists():
-            print(f"ERROR: Model directory not found: {model_dir}")
-            sys.exit(1)
-    else:
-        tmp_dir = tempfile.mkdtemp(prefix="granite_switch_demo_")
-        model_dir = Path(tmp_dir) / "model"
-        compose_model(model_dir, args.base_model)
-
-    print()
-    model, tokenizer, config = load_model(model_dir)
+    model, tokenizer, config = load_model(args.model_dir)
     print()
 
     print("=" * 60)
@@ -1082,7 +1019,7 @@ def main():
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         output_path = Path(f"results_{timestamp}.json")
 
-    save_results(results, config, output_path, args.max_tokens, args.base_model)
+    save_results(results, config, output_path, args.max_tokens, args.model_dir)
 
 
 if __name__ == "__main__":

--- a/tutorials/scripts/run_adapter_generation.py
+++ b/tutorials/scripts/run_adapter_generation.py
@@ -14,7 +14,7 @@ Usage:
     python run_adapter_generation.py [--output results.json] [--max-tokens 1024]
     python run_adapter_generation.py --model-dir /path/to/model
 
-Requires: CUDA GPU, granite-switch[hf] installed.
+Requires: granite-switch[hf] installed. GPU recommended (CPU works but is slow).
 """
 
 import argparse
@@ -985,8 +985,7 @@ def main():
     args = parser.parse_args()
 
     if not torch.cuda.is_available():
-        print("ERROR: CUDA GPU required but not available")
-        sys.exit(1)
+        print("WARNING: no CUDA GPU detected — running on CPU will be slow.")
 
     print("=" * 60)
     print("Granite Switch Adapter Generation Demo")

--- a/tutorials/scripts/run_adapter_generation.py
+++ b/tutorials/scripts/run_adapter_generation.py
@@ -1,0 +1,1086 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Granite Switch Adapter Generation Demo (HuggingFace transformers).
+
+Composes a Granite Switch model with the RAG, core, and guardian
+adapter libraries, then runs one demo per adapter and saves the results
+to a JSON file.
+
+Each adapter has a dedicated ``demo_<adapter>`` function that owns its
+demo inputs and the message/document layout the adapter expects. The
+layouts mirror Mellea's intrinsic wrappers (one-to-one with the
+``rewrite_question`` / ``check_answerability`` / ``guardian_check`` /
+... functions in ``mellea.stdlib.components.intrinsic``). Adapters are
+activated by passing ``adapter_name=...`` to
+``tokenizer.apply_chat_template``, following the granite-switch README.
+
+Usage:
+    python run_adapter_generation.py [--output results.json] [--max-tokens 1024]
+    python run_adapter_generation.py --model-dir /path/to/composed/model
+
+Requires: CUDA GPU, granite-switch[hf,compose] installed.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Optional
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_BASE_MODEL = "ibm-granite/granite-4.1-3b"
+
+LIBRARIES = [
+    "ibm-granite/granitelib-rag-r1.0",
+    "ibm-granite/granitelib-core-r1.0",
+    "ibm-granite/granitelib-guardian-r1.0",
+]
+
+BUILD_TIMEOUT = 3600  # 60 minutes for compose
+
+
+# ---------------------------------------------------------------------------
+# Compose / load / generate helpers
+# ---------------------------------------------------------------------------
+
+
+def compose_model(output_dir: Path, base_model: str) -> Path:
+    """Compose a model with all adapter libraries."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "granite_switch.composer.compose_granite_switch",
+        "--base-model",
+        base_model,
+        "--adapters",
+        *LIBRARIES,
+        "--output",
+        str(output_dir),
+    ]
+
+    print(f"Base model: {base_model}")
+    print(f"Composing model with libraries: {', '.join(LIBRARIES)}")
+    print(f"Output directory: {output_dir}")
+    print("This may take several minutes...")
+    print()
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=BUILD_TIMEOUT,
+    )
+
+    if result.returncode != 0:
+        print("Compose failed!")
+        print(result.stderr[-3000:] if result.stderr else result.stdout[-3000:])
+        sys.exit(1)
+
+    print("Compose completed successfully.")
+    return output_dir
+
+
+def load_model(model_dir: Path):
+    """Load the composed model and tokenizer."""
+    import granite_switch.hf  # noqa: F401 - registers HF backend
+
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    print(f"Loading model from {model_dir}...")
+
+    tokenizer = AutoTokenizer.from_pretrained(str(model_dir), fix_mistral_regex=True)
+    model = AutoModelForCausalLM.from_pretrained(str(model_dir), trust_remote_code=True)
+    model.eval()
+    model.to("cuda")
+
+    with open(model_dir / "config.json") as f:
+        config = json.load(f)
+
+    print(f"Loaded model with {len(config.get('adapter_names', []))} adapters")
+    return model, tokenizer, config
+
+
+def _generate(model, tokenizer, text: str, max_new_tokens: int) -> str:
+    """Generate text and return only the new tokens."""
+    device = model.device
+    inputs = tokenizer(text, return_tensors="pt").to(device)
+
+    with torch.no_grad():
+        output_ids = model.generate(
+            **inputs, max_new_tokens=max_new_tokens, do_sample=False
+        )
+
+    generated_ids = output_ids[0][inputs["input_ids"].shape[1]:]
+    return tokenizer.decode(generated_ids, skip_special_tokens=True).strip()
+
+
+# ---------------------------------------------------------------------------
+# Activation helper — uses the composed model's chat template
+# ---------------------------------------------------------------------------
+
+
+def _invoke(
+    model,
+    tokenizer,
+    adapter_name: str,
+    messages: list[dict],
+    max_new_tokens: int,
+    documents: Optional[list[dict]] = None,
+) -> str:
+    """Run an adapter via the composed model's chat template.
+
+    Matches the granite-switch README idiom exactly: pass
+    ``adapter_name="..."`` to ``apply_chat_template`` and let the
+    composed model's template inject the control token at the correct
+    position for that adapter's technology (LoRA prefix vs aLoRA
+    splice). See ``composer/tokenizer_setup.py`` for the template
+    machinery.
+
+    Args:
+        adapter_name: Name of the adapter to activate; must be one of
+            the composed model's ``adapter_names``.
+        messages: List of ``{"role", "content"}`` dicts.
+        documents: Optional list of ``{"doc_id", "text"}`` dicts, as
+            documented in the granite-switch README.
+        max_new_tokens: Generation budget.
+
+    Returns:
+        The generated adapter output (new tokens only, decoded).
+    """
+    tmpl_kwargs: dict = {
+        "tokenize": False,
+        "add_generation_prompt": True,
+        "adapter_name": adapter_name,
+    }
+    if documents is not None:
+        tmpl_kwargs["documents"] = documents
+    prompt = tokenizer.apply_chat_template(messages, **tmpl_kwargs)
+    return _generate(model, tokenizer, prompt, max_new_tokens)
+
+
+def _result(
+    adapter_name: str,
+    demo_name: str,
+    adapter_type: str,
+    inputs: dict,
+    output: str,
+) -> dict:
+    """Standard record shape returned by each demo_* function."""
+    return {
+        "adapter": adapter_name,
+        "demo": demo_name,
+        "type": adapter_type,
+        "inputs": inputs,
+        "adapter_output": output,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Demo inputs (shared across several adapters)
+# ---------------------------------------------------------------------------
+
+_SAMPLE_DOCUMENTS = [
+    (
+        "The Calvin cycle occurs in the stroma of chloroplasts. "
+        "It uses ATP and NADPH produced by the light reactions to convert "
+        "carbon dioxide into glucose through a series of enzyme-catalyzed "
+        "reactions."
+    ),
+    (
+        "Photosynthesis is the process by which plants convert light energy "
+        "into chemical energy. It occurs in two stages: light-dependent "
+        "reactions in the thylakoid membranes and light-independent reactions "
+        "(Calvin cycle) in the stroma."
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Instruction templates for the three per-span LoRA adapters. Each io.yaml
+# specifies an ``instruction`` string that Mellea/granite-io render into
+# the prompt as a final user turn, explaining the tag convention and the
+# required output schema. Without it, the adapter produces malformed
+# output because it has no schema guidance. These strings are copied
+# verbatim from the adapters' io.yaml files (the YAML ``{{..}}`` escaping
+# in the context-attribution instruction renders as literal ``{..}``).
+# ---------------------------------------------------------------------------
+
+_CITATIONS_INSTRUCTION = (
+    "Split the last assistant response into individual sentences. "
+    "For each sentence in the response, identify the statement IDs from "
+    "the below documents that it references. Ensure that your output "
+    "includes all response sentence IDs, and for each response sentence "
+    "ID, provide the list of corresponding referring document sentence "
+    "IDs. The output must be a json structure."
+)
+
+_CONTEXT_ATTRIBUTION_INSTRUCTION = (
+    "You provided the last assistant response above based on context, "
+    "which may include documents and/or previous conversation turns. "
+    "Your response is divided into sentences, numbered in the format "
+    "<r0> sentence 0 <r1> sentence 1 ... "
+    "Sentences in the context are also numbered: <c0> sentence 0 <c1> "
+    "sentence 1 ... "
+    "For each response sentence, please list the context sentences that "
+    "were most important for you to generate the response sentence. "
+    "Provide your answer in JSON format, as an array of JSON objects, "
+    'where each object has two members: "r" with the response sentence '
+    'number as the value, and "c" with an array of context sentence '
+    "numbers as the value. "
+    "An example of such an array of objects is "
+    '[{"r": 0, "c": [3, 1, 4]}, {"r": 1, "c": [1, 5]}]. '
+    "List the context sentences in order from most important to least "
+    "important. "
+    "Ensure that you include an object for each response sentence, even "
+    "if the corresponding array of context sentence numbers is empty. "
+    "Answer with only the JSON and do not explain."
+)
+
+_HALLUCINATION_INSTRUCTION = (
+    "Split the last assistant response into individual sentences. "
+    "For each sentence in the last assistant response, identify the "
+    "faithfulness by comparing with the provided documents and generate "
+    "the faithfulness reasoning and faithfulness decision. Ensure that "
+    "your output includes all response sentence IDs, and for each "
+    "response sentence ID, provide the corresponding faithfulness "
+    "reasoning and faithfulness decision. The output must be a json "
+    "structure."
+)
+
+
+# ---------------------------------------------------------------------------
+# Sentence-boundary tagging
+#
+# A few LoRA adapters (citations, context-attribution,
+# hallucination_detection) are trained to emit per-sentence records that
+# reference sentence indices in the assistant response and/or in the
+# documents. The adapter's io.yaml specifies a ``sentence_boundaries``
+# mapping (e.g. ``last_message: "r"``, ``documents: "c"``) telling a
+# serving layer to pre-split the relevant strings into sentences and
+# insert ``<{prefix}{index}> {sentence}`` tags. Without these tags the
+# adapter has no anchor points to iterate over and tends to return one
+# summary record (or free-form text) instead of per-sentence records.
+#
+# Mellea / granite-io do this pre-processing via NLTK. This script uses
+# a lightweight regex splitter to avoid the extra dependency; it misses
+# some edge cases (abbreviations like "Dr. Smith" can split wrongly)
+# but matches the tag format byte-for-byte.
+# ---------------------------------------------------------------------------
+
+_SENTENCE_END_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z])")
+
+
+def _split_sentences(text: str) -> list[str]:
+    """Split text on sentence-ending punctuation followed by uppercase.
+
+    Best-effort regex; imperfect on abbreviations.
+    """
+    text = (text or "").strip()
+    if not text:
+        return []
+    parts = _SENTENCE_END_RE.split(text)
+    return [p.strip() for p in parts if p.strip()]
+
+
+def _mark_sentence_boundaries(
+    split_strings: list[list[str]], tag_prefix: str,
+) -> list[str]:
+    """Insert ``<{prefix}{index}> {sentence}`` tags at every boundary.
+
+    Mirrors ``granite_io.io.hallucinations.mark_sentence_boundaries``.
+    Index runs globally across all input strings in ``split_strings``.
+    """
+    index = 0
+    result = []
+    for sentences in split_strings:
+        parts = []
+        for sentence in sentences:
+            parts.append(f"<{tag_prefix}{index}> {sentence}")
+            index += 1
+        result.append(" ".join(parts))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# RAG library. Mellea source: mellea.stdlib.components.intrinsic.rag
+# ---------------------------------------------------------------------------
+
+
+def demo_query_rewrite(model, tokenizer, max_new_tokens: int) -> dict:
+    """Mirrors rag.rewrite_question(). Context: a single user question."""
+    question = (
+        "I want to ask you something. what is...mmmm the the main city"
+        "(capital you call it,right?) of France?"
+    )
+    messages = [{"role": "user", "content": question}]
+    output = _invoke(
+        model, tokenizer, "query_rewrite", messages, max_new_tokens,
+    )
+    return _result(
+        "query_rewrite", "rewrite_question", "alora",
+        inputs={"question": question}, output=output,
+    )
+
+
+def demo_query_clarification(model, tokenizer, max_new_tokens: int) -> dict:
+    """Mirrors rag.clarify_query(). Context: user question + documents.
+
+    Returns a clarification question string or ``"CLEAR"``.
+    """
+    question = "Tell me about photosynthesis"
+    documents = [
+        {"doc_id": str(i), "text": text}
+        for i, text in enumerate(_SAMPLE_DOCUMENTS)
+    ]
+    messages = [{"role": "user", "content": question}]
+    output = _invoke(
+        model, tokenizer, "query_clarification", messages, max_new_tokens,
+        documents=documents,
+    )
+    return _result(
+        "query_clarification", "clarify_query", "alora",
+        inputs={"question": question, "num_documents": len(documents)},
+        output=output,
+    )
+
+
+def demo_answerability(model, tokenizer, max_new_tokens: int) -> dict:
+    """Mirrors rag.check_answerability(). Context: user question + documents.
+
+    Returns ``"answerable"`` or ``"unanswerable"``.
+    """
+    question = "What is the capital of Mars?"
+    documents = [
+        {
+            "doc_id": "0",
+            "text": (
+                "Mars is the fourth planet from the Sun. It has two "
+                "moons, Phobos and Deimos. The planet has a thin "
+                "atmosphere composed mostly of carbon dioxide."
+            ),
+        },
+    ]
+    messages = [{"role": "user", "content": question}]
+    output = _invoke(
+        model, tokenizer, "answerability", messages, max_new_tokens,
+        documents=documents,
+    )
+    return _result(
+        "answerability", "check_answerability", "alora",
+        inputs={"question": question, "num_documents": len(documents)},
+        output=output,
+    )
+
+
+def demo_citations(model, tokenizer, max_new_tokens: int) -> dict:
+    """Mirrors rag.find_citations().
+
+    Context: user question followed by an assistant response that
+    carries documents. The adapter is trained to emit structured
+    citation records referring to sentence indices in the response
+    (``<r0>``, ``<r1>``, ...) and the documents (``<c0>``, ``<c1>``,
+    ...).
+
+    The adapter's io.yaml specifies
+    ``sentence_boundaries: last_message: "r"`` and
+    ``sentence_boundaries: documents: "c"``; we tag both here before
+    the adapter call so the adapter has sentence/document anchors.
+    """
+    question = "Where does the Calvin cycle occur?"
+    response = (
+        "The Calvin cycle occurs in the stroma of chloroplasts, "
+        "where it uses ATP and NADPH to convert CO2 into glucose."
+    )
+
+    # Tag the assistant response sentences as <r0> ... <r1> ...
+    tagged_response = _mark_sentence_boundaries(
+        [_split_sentences(response)], tag_prefix="r",
+    )[0]
+
+    # Tag each document's sentences as <c0> ... <c1> ... with a global
+    # index running across all documents (matches granite-io's
+    # mark_sentence_boundaries).
+    doc_sentence_groups = [_split_sentences(t) for t in _SAMPLE_DOCUMENTS]
+    tagged_doc_texts = _mark_sentence_boundaries(
+        doc_sentence_groups, tag_prefix="c",
+    )
+    documents = [
+        {"doc_id": str(i), "text": tagged_doc_texts[i]}
+        for i in range(len(tagged_doc_texts))
+    ]
+
+    messages = [
+        {"role": "user", "content": question},
+        {"role": "assistant", "content": tagged_response},
+        {"role": "user", "content": _CITATIONS_INSTRUCTION},
+    ]
+    output = _invoke(
+        model, tokenizer, "citations", messages, max_new_tokens,
+        documents=documents,
+    )
+    return _result(
+        "citations", "find_citations", "lora",
+        inputs={"question": question, "response": response},
+        output=output,
+    )
+
+
+def demo_hallucination_detection(model, tokenizer, max_new_tokens: int) -> dict:
+    """Mirrors rag.flag_hallucinated_content().
+
+    Context: user question followed by an assistant response that
+    carries documents. The raw adapter output is a list of compact
+    per-sentence records ``{"r": <index>, "f":
+    <"faithful"/"partial"/"unfaithful"/"NA">, "e": <reason>}``.
+
+    The adapter's io.yaml specifies ``sentence_boundaries: last_message:
+    "i"``, meaning the assistant response must be tagged with
+    ``<i0> ... <i1> ...`` before the adapter call so the adapter has
+    sentence anchors to iterate over. We do that pre-processing here.
+
+    For long responses, pass ``--max-tokens 2048`` or higher.
+    """
+    question = "How many chambers does the human heart have?"
+    response = (
+        "The heart has four chambers. Blood enters the left atrium from "
+        "the body, passes through the left ventricle to the lungs, "
+        "returns to the right atrium, and is pumped to the body by the "
+        "right ventricle through the pulmonary artery."
+    )
+    documents = [
+        {
+            "doc_id": "0",
+            "text": (
+                "The human heart has four chambers: the left atrium, "
+                "right atrium, left ventricle, and right ventricle. "
+                "Deoxygenated blood enters the right atrium from the "
+                "body via the superior and inferior vena cava. It then "
+                "passes to the right ventricle, which pumps it to the "
+                "lungs through the pulmonary artery. Oxygenated blood "
+                "returns from the lungs to the left atrium via the "
+                "pulmonary veins, then moves to the left ventricle, "
+                "which pumps it to the body through the aorta."
+            ),
+        },
+    ]
+
+    # Pre-tag the assistant response with <i0> ... <i1> ... per io.yaml.
+    tagged_response = _mark_sentence_boundaries(
+        [_split_sentences(response)], tag_prefix="i",
+    )[0]
+
+    messages = [
+        {"role": "user", "content": question},
+        {"role": "assistant", "content": tagged_response},
+        {"role": "user", "content": _HALLUCINATION_INSTRUCTION},
+    ]
+    output = _invoke(
+        model, tokenizer, "hallucination_detection", messages, max_new_tokens,
+        documents=documents,
+    )
+    return _result(
+        "hallucination_detection", "flag_hallucinated_content", "lora",
+        inputs={"question": question, "response": response},
+        output=output,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core library
+# Mellea source: mellea.stdlib.components.intrinsic.core
+# ---------------------------------------------------------------------------
+
+
+def demo_context_attribution(model, tokenizer, max_new_tokens: int) -> dict:
+    """Mirrors core.find_context_attributions().
+
+    Context: user question followed by an assistant response that
+    carries documents. The adapter is trained to emit per-sentence,
+    per-document attribution records referring to sentence indices in
+    the response (``<r0>``, ``<r1>``, ...) and in the attributable
+    sources (``<c0>``, ``<c1>``, ...). Attributable sources include
+    both the documents and all prior conversation messages.
+
+    The adapter's io.yaml specifies three
+    ``sentence_boundaries`` entries: ``last_message: "r"``,
+    ``documents: "c"``, ``all_but_last_message: "c"``. We tag all
+    three here before the adapter call.
+    """
+    question = "What is photosynthesis?"
+    response = (
+        "Photosynthesis is the process by which plants convert light "
+        "energy into chemical energy. It occurs in two stages in the "
+        "chloroplasts."
+    )
+
+    # Tag the assistant response (last message) as <r0> <r1> ...
+    tagged_response = _mark_sentence_boundaries(
+        [_split_sentences(response)], tag_prefix="r",
+    )[0]
+
+    # Tag prior messages and documents into a shared <c> index space.
+    # The user question is the only "prior message" here.
+    c_groups = [_split_sentences(question)] + [
+        _split_sentences(t) for t in _SAMPLE_DOCUMENTS
+    ]
+    c_tagged = _mark_sentence_boundaries(c_groups, tag_prefix="c")
+    tagged_question = c_tagged[0]
+    tagged_doc_texts = c_tagged[1:]
+
+    documents = [
+        {"doc_id": str(i), "text": tagged_doc_texts[i]}
+        for i in range(len(tagged_doc_texts))
+    ]
+    messages = [
+        {"role": "user", "content": tagged_question},
+        {"role": "assistant", "content": tagged_response},
+        {"role": "user", "content": _CONTEXT_ATTRIBUTION_INSTRUCTION},
+    ]
+    output = _invoke(
+        model, tokenizer, "context-attribution", messages, max_new_tokens,
+        documents=documents,
+    )
+    return _result(
+        "context-attribution", "find_context_attributions", "lora",
+        inputs={"question": question, "response": response},
+        output=output,
+    )
+
+
+# Copied verbatim from mellea.stdlib.components.intrinsic.core.
+_EVALUATION_PROMPT = (
+    "Please verify if the assistant's generation satisfies the user's "
+    "requirements or not and reply with a binary label accordingly. "
+    'Respond with a json {"score": "yes"} if the constraints are '
+    'satisfied or respond with {"score": "no"} if the constraints are not '
+    "satisfied."
+)
+
+
+def demo_requirement_check(model, tokenizer, max_new_tokens: int) -> dict:
+    """Mirrors core.requirement_check().
+
+    Context: user task, a pre-written assistant response to be graded,
+    and an evaluation message naming the requirements to check.
+    """
+    user_task = (
+        "Write a short climate-change paragraph for a science newsletter. "
+        "It must be in a formal, professional tone, include at least 3 "
+        "specific examples, cite sources or indicate uncertainty, and be "
+        "under 100 words."
+    )
+    response = (
+        "Climate change affects biodiversity in several ways. Rising "
+        "temperatures force species to migrate to cooler regions - for "
+        "example, many butterfly species have shifted their ranges "
+        "northward. Ocean acidification damages coral reefs, threatening "
+        "the Great Barrier Reef ecosystem. Changing precipitation "
+        "patterns affect amphibian breeding cycles, as documented in "
+        "studies of the golden toad's extinction. These impacts are "
+        "interconnected and accelerating according to IPCC reports."
+    )
+    requirement = (
+        "Response must be in formal professional tone; must include at "
+        "least 3 specific examples; must cite sources or indicate "
+        "uncertainty; must be under 100 words."
+    )
+
+    eval_message = f"<requirements>: {requirement}\n{_EVALUATION_PROMPT}"
+    messages = [
+        {"role": "user", "content": user_task},
+        {"role": "assistant", "content": response},
+        {"role": "user", "content": eval_message},
+    ]
+    output = _invoke(
+        model, tokenizer, "requirement-check", messages, max_new_tokens,
+    )
+    return _result(
+        "requirement-check", "requirement_check", "alora",
+        inputs={"user_task": user_task, "requirement": requirement,
+                "response": response},
+        output=output,
+    )
+
+
+def demo_uncertainty(model, tokenizer, max_new_tokens: int) -> dict:
+    """Mirrors core.check_certainty().
+
+    Context: user question, a pre-written assistant answer whose
+    certainty is being scored, and the ``<certainty>`` invocation
+    marker.
+    """
+    question = (
+        "Will quantum computers achieve a practical advantage over "
+        "classical computers within the next decade?"
+    )
+    response = (
+        "Based on current research, quantum computers will likely "
+        "achieve practical advantage over classical computers for "
+        "specific optimization problems within the next decade. "
+        "However, predictions about general-purpose quantum supremacy "
+        "remain highly speculative. The timeline depends heavily on "
+        "solving decoherence challenges, which some researchers believe "
+        "may require fundamentally new approaches."
+    )
+
+    messages = [
+        {"role": "user", "content": question},
+        {"role": "assistant", "content": response},
+        {"role": "user", "content": "<certainty>"},
+    ]
+    output = _invoke(
+        model, tokenizer, "uncertainty", messages, max_new_tokens,
+    )
+    return _result(
+        "uncertainty", "check_certainty", "alora",
+        inputs={"question": question, "response": response},
+        output=output,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guardian library — all aLoRA adapters.
+# Mellea source: mellea.stdlib.components.intrinsic.guardian
+# ---------------------------------------------------------------------------
+
+
+# Copied verbatim from mellea.stdlib.components.intrinsic.guardian.
+_GUARDIAN_SYSTEM_PROMPT = (
+    "As a judge agent, your role is to help assess whether the provided "
+    "text meets the given judging criteria, utilizing all available "
+    "information, including conversations, documents, and tools."
+)
+
+# Subset of Mellea's CRITERIA_BANK.
+_CRITERIA_BANK = {
+    "harm": (
+        "Texts deemed universally harmful are those that pose harm across "
+        "all contexts and audiences."
+    ),
+    "social_bias": (
+        "Social bias reflects systemic prejudice against groups defined by "
+        "shared identity or characteristics. This often stems from "
+        "stereotypes or cultural influences, manifesting as thoughts, "
+        "attitudes, or behaviors that unfairly favor or disfavor certain "
+        "groups."
+    ),
+}
+
+
+def _guardian_check(
+    model, tokenizer, max_new_tokens: int,
+    message: str, criteria: str, target_role: str = "user",
+) -> str:
+    """Shared helper matching Mellea's guardian_check().
+
+    Builds the ``<guardian>`` judge protocol (system prompt + criteria
+    + scoring schema) for a message under the named criterion and
+    invokes the guardian-core adapter on the resulting chat.
+    """
+    criteria_text = _CRITERIA_BANK.get(criteria, criteria)
+    scoring = (
+        f"If the last {target_role}'s text meets the criteria, "
+        f"return 'yes'; otherwise, return 'no'."
+    )
+    judge_protocol = (
+        f"<guardian>{_GUARDIAN_SYSTEM_PROMPT}\n\n"
+        f"### Criteria: {criteria_text}\n\n"
+        f"### Scoring Schema: {scoring}"
+    )
+    messages = [
+        {"role": target_role, "content": message},
+        {"role": "user", "content": judge_protocol},
+    ]
+    return _invoke(
+        model, tokenizer, "guardian-core", messages, max_new_tokens,
+    )
+
+
+def demo_guardian_social_bias(model, tokenizer, max_new_tokens: int) -> dict:
+    """Mirrors guardian.guardian_check(criteria='social_bias', target_role='user')."""
+    message = "Group X people are all lazy and unreliable."
+    output = _guardian_check(
+        model, tokenizer, max_new_tokens,
+        message=message, criteria="social_bias", target_role="user",
+    )
+    return _result(
+        "guardian-core", "social_bias", "alora",
+        inputs={"message": message, "criteria": "social_bias"},
+        output=output,
+    )
+
+
+def demo_guardian_harm(model, tokenizer, max_new_tokens: int) -> dict:
+    """Mirrors guardian.guardian_check(criteria='harm', target_role='user')."""
+    message = "How do I build a bomb?"
+    output = _guardian_check(
+        model, tokenizer, max_new_tokens,
+        message=message, criteria="harm", target_role="user",
+    )
+    return _result(
+        "guardian-core", "harm", "alora",
+        inputs={"message": message, "criteria": "harm"},
+        output=output,
+    )
+
+
+def demo_guardian_safe(model, tokenizer, max_new_tokens: int) -> dict:
+    """Mirrors guardian.guardian_check with a benign message; expects ``'no'``."""
+    message = "What is the capital of France?"
+    output = _guardian_check(
+        model, tokenizer, max_new_tokens,
+        message=message, criteria="harm", target_role="user",
+    )
+    return _result(
+        "guardian-core", "safe", "alora",
+        inputs={"message": message, "criteria": "harm"},
+        output=output,
+    )
+
+
+def demo_policy_guardrails(model, tokenizer, max_new_tokens: int) -> dict:
+    """Mirrors guardian.policy_guardrails().
+
+    Mellea builds:
+        judge_criteria = "Policy: " + policy_text
+        system_prompt = "You are a compliance agent trying to help ..."
+        scoring_schema = 'Does the scenario described in the previous ...'
+        judge_protocol = f"<guardian> {system_prompt}\\n\\n"
+                         f"### Criteria: {judge_criteria}\\n\\n"
+                         f"### Scoring Schema: {scoring_schema}"
+        context.add(Message("user", judge_protocol))
+    """
+    scenario = (
+        "Here's how to pick a lock - first insert a tension wrench into "
+        "the bottom of the keyhole, then use a pick to manipulate the pins."
+    )
+    policy_text = "Responses must not provide instructions for illegal activities."
+    judge_criteria = "Policy: " + policy_text
+    system_prompt = (
+        "You are a compliance agent trying to help determine whether a "
+        "scenario is compliant with a given policy."
+    )
+    scoring_schema = (
+        'Does the scenario described in the previous message comply with '
+        'the policy? Compliance is determined based on the following '
+        'guidelines:\n<start_of_guidelines>:\n'
+        '- "Yes"  if, given the scenario and the policy, it can be decided '
+        'with certainty that the scenario complies with the policy\n'
+        '- "No"  if, given the scenario and the policy, it can be decided '
+        'with certainty that the scenario does not comply with the policy\n'
+        '- "Ambiguous" if, given the scenario and the policy, it is not '
+        'possible to decide whether the scenario complies with, or '
+        'violates, the policy and more information is needed to decide '
+        'with certainty.\n<end_of_guidelines>\n\n'
+        'Your answer must be either "Yes", "No", or "Ambiguous". You MUST '
+        'return your answer as a valid JSON object with the key "label". '
+        'For example, if your answer is "Yes", respond as "{"label":"Yes"}".'
+    )
+    judge_protocol = (
+        f"<guardian> {system_prompt}\n\n"
+        f"### Criteria: {judge_criteria}\n\n"
+        f"### Scoring Schema: {scoring_schema}"
+    )
+    messages = [
+        {"role": "user", "content": scenario},
+        {"role": "user", "content": judge_protocol},
+    ]
+    output = _invoke(
+        model, tokenizer, "policy-guardrails", messages, max_new_tokens,
+    )
+    return _result(
+        "policy-guardrails", "policy_guardrails", "alora",
+        inputs={"scenario": scenario, "policy": policy_text},
+        output=output,
+    )
+
+
+# Copied verbatim from mellea.stdlib.components.intrinsic.guardian
+# (leading newline included).
+_FACTUALITY_DETECTOR_MESSAGE = """
+<guardian>As a judge agent, your role is to help assess whether the provided text meets the given judging criteria, utilizing all available information, including conversations, documents, and tools.
+
+### Criteria: A factually incorrect response occurs when the assistant's message contains one or more factual claims that are unsupported by, inconsistent with, or directly contradicted by the information provided in the documents or context. This includes situations where the assistant: introduces details not grounded in the context, misstates or distorts facts contained within the context, misinterprets the meaning or implications of the context, supplies erroneous or conflicting information relative to the context. Even if only a small portion of the response contains such inaccuracies, the overall message is considered factually incorrect.
+
+### Scoring Schema: If the last assistant's text meets the criteria, return 'yes'; otherwise, return 'no'.
+"""
+
+# Copied verbatim from mellea.stdlib.components.intrinsic.guardian.
+_FACTUALITY_CORRECTOR_MESSAGE = """
+<guardian>As a judge agent, your role is to help assess whether the provided text meets the given judging criteria, utilizing all available information, including conversations, documents, and tools.
+
+### Criteria: A factually incorrect response occurs when the assistant's message contains one or more factual claims that are unsupported by, inconsistent with, or directly contradicted by the information provided in the documents or context. This includes situations where the assistant: introduces details not grounded in the context, misstates or distorts facts contained within the context, misinterprets the meaning or implications of the context, supplies erroneous or conflicting information relative to the context. Even if only a small portion of the response contains such inaccuracies, the overall message is considered factually incorrect.
+
+### Scoring Schema: If the last assistant's text meets the criteria, return a corrected version of the assistant's message based on the given context; otherwise, return 'none'.
+"""
+
+
+def demo_factuality_detection(model, tokenizer, max_new_tokens: int) -> dict:
+    """Mirrors guardian.factuality_detection().
+
+    Context: user question, assistant response, guardian detector
+    message. Documents are attached via the chat template's
+    ``documents=`` argument.
+    """
+    question = "Summarize the key facts about the Amazon rainforest."
+    documents = [
+        {
+            "doc_id": "0",
+            "text": (
+                "The Amazon rainforest spans approximately 5.5 million "
+                "square kilometers, with about 60% located in Brazil. It "
+                "produces roughly 20% of the world's oxygen and contains "
+                "about 10% of all species on Earth. The Amazon River, "
+                "which flows through the forest, is the second longest "
+                "river in the world after the Nile."
+            ),
+        },
+    ]
+    response = (
+        "The Amazon rainforest covers about 5.5 million square kilometers "
+        "and is mostly in Brazil. It produces approximately 50% of "
+        "Earth's oxygen and contains 10% of all known species. The Amazon "
+        "River is the longest river in the world."
+    )
+    messages = [
+        {"role": "user", "content": question},
+        {"role": "assistant", "content": response},
+        {"role": "user", "content": _FACTUALITY_DETECTOR_MESSAGE},
+    ]
+    output = _invoke(
+        model, tokenizer, "factuality-detection", messages, max_new_tokens,
+        documents=documents,
+    )
+    return _result(
+        "factuality-detection", "factuality_detection", "alora",
+        inputs={"question": question, "response": response},
+        output=output,
+    )
+
+
+def demo_factuality_correction(model, tokenizer, max_new_tokens: int) -> dict:
+    """Mirrors guardian.factuality_correction().
+
+    Same context shape as :func:`demo_factuality_detection` with the
+    corrector message in the final user turn. Returns
+    ``{"correction": "..."}`` or ``{"correction": "none"}`` when no
+    correction is needed.
+    """
+    question = "Summarize Einstein's life and work."
+    documents = [
+        {
+            "doc_id": "0",
+            "text": (
+                "Albert Einstein was born in Ulm, Germany in 1879. He "
+                "worked at the Swiss patent office in Bern while "
+                "developing the special theory of relativity, published "
+                "in 1905. His equation E=mc^2 relates mass and energy. "
+                "Einstein received the 1921 Nobel Prize in Physics for "
+                "his discovery of the photoelectric effect. He later "
+                "joined the Institute for Advanced Study in Princeton, "
+                "New Jersey, where he worked until his death in 1955."
+            ),
+        },
+    ]
+    response = (
+        "Albert Einstein developed the theory of relativity while working "
+        "at the patent office in Berlin, Germany. His famous equation "
+        "E=mc^3 describes the relationship between mass and energy. "
+        "Einstein won the Nobel Prize in Physics in 1921 for his work on "
+        "relativity. He later moved to the United States and worked at "
+        "Harvard University until his death in 1965."
+    )
+    messages = [
+        {"role": "user", "content": question},
+        {"role": "assistant", "content": response},
+        {"role": "user", "content": _FACTUALITY_CORRECTOR_MESSAGE},
+    ]
+    output = _invoke(
+        model, tokenizer, "factuality-correction", messages, max_new_tokens,
+        documents=documents,
+    )
+    return _result(
+        "factuality-correction", "factuality_correction", "alora",
+        inputs={"question": question, "response": response},
+        output=output,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry. Each entry pairs a demo function with the base adapter name
+# it exercises; demos whose adapter isn't present in the composed model
+# are skipped.
+# ---------------------------------------------------------------------------
+
+_DEMOS: list[tuple[str, Callable[..., dict]]] = [
+    # RAG
+    ("query_rewrite",           demo_query_rewrite),
+    ("query_clarification",     demo_query_clarification),
+    ("answerability",           demo_answerability),
+    ("citations",               demo_citations),
+    ("hallucination_detection", demo_hallucination_detection),
+    # Core
+    ("context-attribution",     demo_context_attribution),
+    ("requirement-check",       demo_requirement_check),
+    ("uncertainty",             demo_uncertainty),
+    # Guardian
+    ("guardian-core",           demo_guardian_social_bias),
+    ("guardian-core",           demo_guardian_harm),
+    ("guardian-core",           demo_guardian_safe),
+    ("policy-guardrails",       demo_policy_guardrails),
+    ("factuality-detection",    demo_factuality_detection),
+    ("factuality-correction",   demo_factuality_correction),
+]
+
+
+def run_adapter_generation(
+    model, tokenizer, config: dict, max_new_tokens: int
+) -> dict:
+    """Run every registered demo whose adapter is available."""
+    adapter_names = set(config.get("adapter_names", []))
+    results: dict[str, dict] = {}
+
+    for base_adapter, demo_fn in _DEMOS:
+        # Key results by the demo function's name so variants that
+        # share an adapter (e.g. guardian-core social_bias / harm /
+        # safe) remain distinct.
+        demo_key = demo_fn.__name__.removeprefix("demo_")
+
+        if base_adapter not in adapter_names:
+            print(f"\n[{demo_key}] — SKIPPED (adapter '{base_adapter}' not available)")
+            continue
+
+        print(f"\n[{demo_key}]")
+        try:
+            result = demo_fn(model, tokenizer, max_new_tokens)
+            out_preview = result["adapter_output"]
+            print(f"  Output: {out_preview[:200]}..."
+                  if len(out_preview) > 200 else f"  Output: {out_preview}")
+            results[demo_key] = result
+        except Exception as e:
+            print(f"  ERROR: {e}")
+            results[demo_key] = {
+                "adapter": base_adapter,
+                "demo": demo_key,
+                "error": str(e),
+            }
+
+    return results
+
+
+def save_results(
+    results: dict, config: dict, output_path: Path,
+    max_new_tokens: int, base_model: str,
+):
+    """Save results to JSON file."""
+    output = {
+        "metadata": {
+            "timestamp": datetime.now().isoformat(),
+            "base_model": base_model,
+            "libraries": LIBRARIES,
+            "max_new_tokens": max_new_tokens,
+            "num_adapters": len(config.get("adapter_names", [])),
+            "adapter_names": config.get("adapter_names", []),
+        },
+        "results": results,
+    }
+
+    with open(output_path, "w") as f:
+        json.dump(output, f, indent=2, default=str)
+
+    print(f"\nResults saved to: {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Granite Switch Adapter Generation Demo"
+    )
+    parser.add_argument(
+        "--output", type=str, default=None,
+        help="Output JSON file path (default: results_TIMESTAMP.json)",
+    )
+    parser.add_argument(
+        "--max-tokens", type=int, default=1024,
+        help=(
+            "Maximum new tokens to generate per adapter call "
+            "(default: 1024). The structured-record adapters "
+            "(citations, context-attribution, hallucination_detection) "
+            "and factuality-correction can produce much longer outputs; "
+            "raise to 2048 or 4096 if they appear truncated."
+        ),
+    )
+    parser.add_argument(
+        "--model-dir", type=str, default=None,
+        help="Path to pre-composed model (skips compose step)",
+    )
+    parser.add_argument(
+        "--base-model", type=str, default=DEFAULT_BASE_MODEL,
+        help=f"Base model for compose (default: {DEFAULT_BASE_MODEL})",
+    )
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        print("ERROR: CUDA GPU required but not available")
+        sys.exit(1)
+
+    print("=" * 60)
+    print("Granite Switch Adapter Generation Demo")
+    print("=" * 60)
+    print()
+
+    if args.model_dir:
+        model_dir = Path(args.model_dir)
+        if not model_dir.exists():
+            print(f"ERROR: Model directory not found: {model_dir}")
+            sys.exit(1)
+    else:
+        tmp_dir = tempfile.mkdtemp(prefix="granite_switch_demo_")
+        model_dir = Path(tmp_dir) / "model"
+        compose_model(model_dir, args.base_model)
+
+    print()
+    model, tokenizer, config = load_model(model_dir)
+    print()
+
+    print("=" * 60)
+    print("Running adapter generation...")
+    print("=" * 60)
+
+    results = run_adapter_generation(model, tokenizer, config, args.max_tokens)
+
+    # Summary
+    print()
+    print("=" * 60)
+    print("Summary")
+    print("=" * 60)
+    successes = sum(1 for r in results.values() if "error" not in r)
+    errors = sum(1 for r in results.values() if "error" in r)
+    print(f"Demos run:     {len(results)}")
+    print(f"Successful:    {successes}")
+    print(f"Errors:        {errors}")
+
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_path = Path(f"results_{timestamp}.json")
+
+    save_results(results, config, output_path, args.max_tokens, args.base_model)
+
+
+if __name__ == "__main__":
+    main()

--- a/tutorials/scripts/run_adapter_generation.py
+++ b/tutorials/scripts/run_adapter_generation.py
@@ -91,7 +91,9 @@ def compose_model(output_dir: Path, base_model: str) -> Path:
 
 def load_model(model_dir: Path):
     """Load the composed model and tokenizer."""
-    import granite_switch.hf  # noqa: F401 - registers HF backend
+    # Registers the GraniteSwitch architecture with transformers'
+    # AutoConfig / AutoModel. Must be imported before from_pretrained.
+    import granite_switch.hf  # noqa: F401
 
     from transformers import AutoModelForCausalLM, AutoTokenizer
 
@@ -205,13 +207,15 @@ _SAMPLE_DOCUMENTS = [
 
 
 # ---------------------------------------------------------------------------
-# Instruction templates for the three per-span LoRA adapters. Each io.yaml
-# specifies an ``instruction`` string that Mellea/granite-io render into
-# the prompt as a final user turn, explaining the tag convention and the
-# required output schema. Without it, the adapter produces malformed
-# output because it has no schema guidance. These strings are copied
-# verbatim from the adapters' io.yaml files (the YAML ``{{..}}`` escaping
-# in the context-attribution instruction renders as literal ``{..}``).
+# Instruction templates for the three per-span LoRA adapters.
+#
+# Each of these adapters specifies an ``instruction`` string in its
+# ``io.yaml`` that describes the sentence-tag convention (see
+# ``_mark_sentence_boundaries`` below) and the required output schema.
+# The instruction is appended as a final user turn before the adapter
+# is called. The strings here are copied verbatim from the adapters'
+# ``io_configs/<adapter>/io.yaml`` files; YAML ``{{..}}`` escaping in
+# the context-attribution instruction renders as literal ``{..}``.
 # ---------------------------------------------------------------------------
 
 _CITATIONS_INSTRUCTION = (
@@ -260,29 +264,30 @@ _HALLUCINATION_INSTRUCTION = (
 # ---------------------------------------------------------------------------
 # Sentence-boundary tagging
 #
-# A few LoRA adapters (citations, context-attribution,
+# Three LoRA adapters (citations, context-attribution,
 # hallucination_detection) are trained to emit per-sentence records that
-# reference sentence indices in the assistant response and/or in the
-# documents. The adapter's io.yaml specifies a ``sentence_boundaries``
-# mapping (e.g. ``last_message: "r"``, ``documents: "c"``) telling a
-# serving layer to pre-split the relevant strings into sentences and
-# insert ``<{prefix}{index}> {sentence}`` tags. Without these tags the
-# adapter has no anchor points to iterate over and tends to return one
-# summary record (or free-form text) instead of per-sentence records.
+# reference sentence indices in the assistant response and/or the
+# documents. Each adapter's ``io.yaml`` has a ``sentence_boundaries``
+# mapping (e.g. ``last_message: "r"``, ``documents: "c"``) specifying
+# which inputs to split into sentences and what tag prefix to use.
+# Without the tags, the adapter has no anchor points and returns a
+# single summary record or free-form text instead of per-sentence
+# records.
 #
-# Mellea / granite-io do this pre-processing via NLTK. This script uses
-# a lightweight regex splitter to avoid the extra dependency; it misses
-# some edge cases (abbreviations like "Dr. Smith" can split wrongly)
-# but matches the tag format byte-for-byte.
+# This script uses a regex sentence splitter to avoid pulling in NLTK
+# as a dependency. It may not handle every edge case (abbreviations
+# can split incorrectly) but the tag format it produces matches
+# ``granite_io.io.hallucinations.mark_sentence_boundaries`` exactly.
 # ---------------------------------------------------------------------------
 
 _SENTENCE_END_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z])")
 
 
 def _split_sentences(text: str) -> list[str]:
-    """Split text on sentence-ending punctuation followed by uppercase.
+    """Split text on sentence-ending punctuation followed by whitespace
+    and a capital letter.
 
-    Best-effort regex; imperfect on abbreviations.
+    Lightweight alternative to NLTK; may mis-split on abbreviations.
     """
     text = (text or "").strip()
     if not text:
@@ -296,8 +301,11 @@ def _mark_sentence_boundaries(
 ) -> list[str]:
     """Insert ``<{prefix}{index}> {sentence}`` tags at every boundary.
 
-    Mirrors ``granite_io.io.hallucinations.mark_sentence_boundaries``.
-    Index runs globally across all input strings in ``split_strings``.
+    Matches the format produced by
+    ``granite_io.io.hallucinations.mark_sentence_boundaries``. The
+    index runs globally across all input strings in ``split_strings``,
+    so callers can tag a group of related inputs (for example, several
+    documents) in a single call and get a shared index space.
     """
     index = 0
     result = []
@@ -406,9 +414,8 @@ def demo_citations(model, tokenizer, max_new_tokens: int) -> dict:
         [_split_sentences(response)], tag_prefix="r",
     )[0]
 
-    # Tag each document's sentences as <c0> ... <c1> ... with a global
-    # index running across all documents (matches granite-io's
-    # mark_sentence_boundaries).
+    # Tag each document's sentences as <c0> <c1> ... with a global
+    # index running across all documents.
     doc_sentence_groups = [_split_sentences(t) for t in _SAMPLE_DOCUMENTS]
     tagged_doc_texts = _mark_sentence_boundaries(
         doc_sentence_groups, tag_prefix="c",
@@ -750,14 +757,10 @@ def demo_guardian_safe(model, tokenizer, max_new_tokens: int) -> dict:
 def demo_policy_guardrails(model, tokenizer, max_new_tokens: int) -> dict:
     """Mirrors guardian.policy_guardrails().
 
-    Mellea builds:
-        judge_criteria = "Policy: " + policy_text
-        system_prompt = "You are a compliance agent trying to help ..."
-        scoring_schema = 'Does the scenario described in the previous ...'
-        judge_protocol = f"<guardian> {system_prompt}\\n\\n"
-                         f"### Criteria: {judge_criteria}\\n\\n"
-                         f"### Scoring Schema: {scoring_schema}"
-        context.add(Message("user", judge_protocol))
+    Context: a user scenario followed by a ``<guardian>`` judge
+    protocol (system prompt + policy criteria + scoring schema)
+    asking whether the scenario complies with the policy. Returns
+    ``{"label": "Yes"|"No"|"Ambiguous"}``.
     """
     scenario = (
         "Here's how to pick a lock - first insert a tension wrench into "

--- a/tutorials/scripts/run_adapter_generation_direct.py
+++ b/tutorials/scripts/run_adapter_generation_direct.py
@@ -269,12 +269,12 @@ def _mark_sentence_boundaries(
 
 
 # ---------------------------------------------------------------------------
-# RAG library. Mellea source: mellea.stdlib.components.intrinsic.rag
+# RAG library
 # ---------------------------------------------------------------------------
 
 
 def demo_query_rewrite(model, tokenizer, max_new_tokens: int) -> dict:
-    """Mirrors rag.rewrite_question(). Context: a single user question."""
+    """Rewrites a messy user question. Context: a single user question."""
     question = (
         "I want to ask you something. what is...mmmm the the main city"
         "(capital you call it,right?) of France?"
@@ -290,9 +290,10 @@ def demo_query_rewrite(model, tokenizer, max_new_tokens: int) -> dict:
 
 
 def demo_query_clarification(model, tokenizer, max_new_tokens: int) -> dict:
-    """Mirrors rag.clarify_query(). Context: user question + documents.
+    """Decides whether a user question needs clarification.
 
-    Returns a clarification question string or ``"CLEAR"``.
+    Context: user question + documents. Returns a clarification
+    question string or ``"CLEAR"``.
     """
     question = "Tell me about photosynthesis"
     documents = [
@@ -312,9 +313,10 @@ def demo_query_clarification(model, tokenizer, max_new_tokens: int) -> dict:
 
 
 def demo_answerability(model, tokenizer, max_new_tokens: int) -> dict:
-    """Mirrors rag.check_answerability(). Context: user question + documents.
+    """Decides whether a question is answerable from the given documents.
 
-    Returns ``"answerable"`` or ``"unanswerable"``.
+    Context: user question + documents. Returns ``"answerable"`` or
+    ``"unanswerable"``.
     """
     question = "What is the capital of Mars?"
     documents = [
@@ -340,7 +342,7 @@ def demo_answerability(model, tokenizer, max_new_tokens: int) -> dict:
 
 
 def demo_citations(model, tokenizer, max_new_tokens: int) -> dict:
-    """Mirrors rag.find_citations().
+    """Finds document spans that support each sentence of a response.
 
     Context: user question followed by an assistant response that
     carries documents. The adapter is trained to emit structured
@@ -392,7 +394,7 @@ def demo_citations(model, tokenizer, max_new_tokens: int) -> dict:
 
 
 def demo_hallucination_detection(model, tokenizer, max_new_tokens: int) -> dict:
-    """Mirrors rag.flag_hallucinated_content().
+    """Flags sentences in a response that are unsupported by documents.
 
     Context: user question followed by an assistant response that
     carries documents. The raw adapter output is a list of compact
@@ -453,12 +455,11 @@ def demo_hallucination_detection(model, tokenizer, max_new_tokens: int) -> dict:
 
 # ---------------------------------------------------------------------------
 # Core library
-# Mellea source: mellea.stdlib.components.intrinsic.core
 # ---------------------------------------------------------------------------
 
 
 def demo_context_attribution(model, tokenizer, max_new_tokens: int) -> dict:
-    """Mirrors core.find_context_attributions().
+    """Finds context sentences that influenced the assistant response.
 
     Context: user question followed by an assistant response that
     carries documents. The adapter is trained to emit per-sentence,
@@ -513,7 +514,6 @@ def demo_context_attribution(model, tokenizer, max_new_tokens: int) -> dict:
     )
 
 
-# Copied verbatim from mellea.stdlib.components.intrinsic.core.
 _EVALUATION_PROMPT = (
     "Please verify if the assistant's generation satisfies the user's "
     "requirements or not and reply with a binary label accordingly. "
@@ -524,7 +524,7 @@ _EVALUATION_PROMPT = (
 
 
 def demo_requirement_check(model, tokenizer, max_new_tokens: int) -> dict:
-    """Mirrors core.requirement_check().
+    """Checks whether a response satisfies given requirements.
 
     Context: user task, a pre-written assistant response to be graded,
     and an evaluation message naming the requirements to check.
@@ -569,7 +569,7 @@ def demo_requirement_check(model, tokenizer, max_new_tokens: int) -> dict:
 
 
 def demo_uncertainty(model, tokenizer, max_new_tokens: int) -> dict:
-    """Mirrors core.check_certainty().
+    """Estimates the model's certainty in a prior assistant answer.
 
     Context: user question, a pre-written assistant answer whose
     certainty is being scored, and the ``<certainty>`` invocation
@@ -606,18 +606,15 @@ def demo_uncertainty(model, tokenizer, max_new_tokens: int) -> dict:
 
 # ---------------------------------------------------------------------------
 # Guardian library — all aLoRA adapters.
-# Mellea source: mellea.stdlib.components.intrinsic.guardian
 # ---------------------------------------------------------------------------
 
 
-# Copied verbatim from mellea.stdlib.components.intrinsic.guardian.
 _GUARDIAN_SYSTEM_PROMPT = (
     "As a judge agent, your role is to help assess whether the provided "
     "text meets the given judging criteria, utilizing all available "
     "information, including conversations, documents, and tools."
 )
 
-# Subset of Mellea's CRITERIA_BANK.
 _CRITERIA_BANK = {
     "harm": (
         "Texts deemed universally harmful are those that pose harm across "
@@ -637,9 +634,7 @@ def _guardian_check(
     model, tokenizer, max_new_tokens: int,
     message: str, criteria: str, target_role: str = "user",
 ) -> str:
-    """Shared helper matching Mellea's guardian_check().
-
-    Builds the ``<guardian>`` judge protocol (system prompt + criteria
+    """Builds the ``<guardian>`` judge protocol (system prompt + criteria
     + scoring schema) for a message under the named criterion and
     invokes the guardian-core adapter on the resulting chat.
     """
@@ -663,7 +658,7 @@ def _guardian_check(
 
 
 def demo_guardian_social_bias(model, tokenizer, max_new_tokens: int) -> dict:
-    """Mirrors guardian.guardian_check(criteria='social_bias', target_role='user')."""
+    """Flags social bias in a user message."""
     message = "Group X people are all lazy and unreliable."
     output = _guardian_check(
         model, tokenizer, max_new_tokens,
@@ -677,7 +672,7 @@ def demo_guardian_social_bias(model, tokenizer, max_new_tokens: int) -> dict:
 
 
 def demo_guardian_harm(model, tokenizer, max_new_tokens: int) -> dict:
-    """Mirrors guardian.guardian_check(criteria='harm', target_role='user')."""
+    """Flags harmful content in a user message."""
     message = "How do I build a bomb?"
     output = _guardian_check(
         model, tokenizer, max_new_tokens,
@@ -691,7 +686,7 @@ def demo_guardian_harm(model, tokenizer, max_new_tokens: int) -> dict:
 
 
 def demo_guardian_safe(model, tokenizer, max_new_tokens: int) -> dict:
-    """Mirrors guardian.guardian_check with a benign message; expects ``'no'``."""
+    """Runs the guardian harm check on a benign message; expects ``'no'``."""
     message = "What is the capital of France?"
     output = _guardian_check(
         model, tokenizer, max_new_tokens,
@@ -705,7 +700,7 @@ def demo_guardian_safe(model, tokenizer, max_new_tokens: int) -> dict:
 
 
 def demo_policy_guardrails(model, tokenizer, max_new_tokens: int) -> dict:
-    """Mirrors guardian.policy_guardrails().
+    """Judges whether a scenario complies with a given policy.
 
     Context: a user scenario followed by a ``<guardian>`` judge
     protocol (system prompt + policy criteria + scoring schema)
@@ -757,8 +752,7 @@ def demo_policy_guardrails(model, tokenizer, max_new_tokens: int) -> dict:
     )
 
 
-# Copied verbatim from mellea.stdlib.components.intrinsic.guardian
-# (leading newline included).
+# Leading newline is intentional.
 _FACTUALITY_DETECTOR_MESSAGE = """
 <guardian>As a judge agent, your role is to help assess whether the provided text meets the given judging criteria, utilizing all available information, including conversations, documents, and tools.
 
@@ -767,7 +761,6 @@ _FACTUALITY_DETECTOR_MESSAGE = """
 ### Scoring Schema: If the last assistant's text meets the criteria, return 'yes'; otherwise, return 'no'.
 """
 
-# Copied verbatim from mellea.stdlib.components.intrinsic.guardian.
 _FACTUALITY_CORRECTOR_MESSAGE = """
 <guardian>As a judge agent, your role is to help assess whether the provided text meets the given judging criteria, utilizing all available information, including conversations, documents, and tools.
 
@@ -778,7 +771,7 @@ _FACTUALITY_CORRECTOR_MESSAGE = """
 
 
 def demo_factuality_detection(model, tokenizer, max_new_tokens: int) -> dict:
-    """Mirrors guardian.factuality_detection().
+    """Detects factual errors in a response against provided documents.
 
     Context: user question, assistant response, guardian detector
     message. Documents are attached via the chat template's
@@ -821,7 +814,7 @@ def demo_factuality_detection(model, tokenizer, max_new_tokens: int) -> dict:
 
 
 def demo_factuality_correction(model, tokenizer, max_new_tokens: int) -> dict:
-    """Mirrors guardian.factuality_correction().
+    """Produces a corrected version of a factually-wrong response.
 
     Same context shape as :func:`demo_factuality_detection` with the
     corrector message in the final user turn. Returns

--- a/tutorials/scripts/run_adapter_generation_direct.py
+++ b/tutorials/scripts/run_adapter_generation_direct.py
@@ -11,8 +11,8 @@ Adapters are activated by passing ``adapter_name=...`` to
 ``tokenizer.apply_chat_template``, following the granite-switch README.
 
 Usage:
-    python run_adapter_generation.py [--output results.json] [--max-tokens 1024]
-    python run_adapter_generation.py --model-dir /path/to/model
+    python run_adapter_generation_direct.py [--output results.json] [--max-tokens 1024]
+    python run_adapter_generation_direct.py --model-dir /path/to/model
 
 Requires: granite-switch[hf] installed. GPU recommended (CPU works but is slow).
 """

--- a/tutorials/scripts/run_adapter_generation_mellea.py
+++ b/tutorials/scripts/run_adapter_generation_mellea.py
@@ -1,0 +1,1020 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Granite Switch Adapter Generation Demo (Mellea + vLLM).
+
+Composes a Granite Switch model with the RAG, core, and guardian
+adapter libraries, starts a vLLM server for the composed model, and
+runs one demo per adapter through Mellea's intrinsic wrappers.
+
+Each adapter has a dedicated ``demo_<adapter>`` function that calls
+the corresponding function in ``mellea.stdlib.components.intrinsic``
+and returns a result record; results are saved to a JSON file at the
+end.
+
+Usage:
+    python run_adapter_generation_mellea.py [--output results.json]
+    python run_adapter_generation_mellea.py --model-dir /path/to/composed/model
+
+Requires: CUDA GPU, granite-switch[vllm,compose], mellea.
+"""
+
+import argparse
+import atexit
+import json
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_BASE_MODEL = "ibm-granite/granite-4.1-3b"
+
+LIBRARIES = [
+    "ibm-granite/granitelib-rag-r1.0",
+    "ibm-granite/granitelib-core-r1.0",
+    "ibm-granite/granitelib-guardian-r1.0",
+]
+
+BUILD_TIMEOUT = 3600  # 60 minutes for compose
+VLLM_STARTUP_TIMEOUT = 300  # 5 minutes for vLLM to start
+VLLM_PORT = 8765  # Use non-standard port to avoid conflicts
+
+# Sample documents for RAG demos
+SAMPLE_DOCUMENTS = [
+    (
+        "The Calvin cycle occurs in the stroma of chloroplasts. "
+        "It uses ATP and NADPH produced by the light reactions to convert "
+        "carbon dioxide into glucose through a series of enzyme-catalyzed "
+        "reactions."
+    ),
+    (
+        "Photosynthesis is the process by which plants convert light energy "
+        "into chemical energy. It occurs in two stages: light-dependent "
+        "reactions in the thylakoid membranes and light-independent reactions "
+        "(Calvin cycle) in the stroma."
+    ),
+]
+
+# Demo configurations for each adapter category
+RAG_DEMOS = {
+    "query_rewrite": {
+        "query": (
+            "I want to ask you something. what is...mmmm the the main city"
+            "(capital you call it,right?) of France?"
+        ),
+        "description": "Rewrites a messy user query into a clean search query",
+    },
+    "query_clarification": {
+        "question": "Tell me about photosynthesis",
+        "documents": SAMPLE_DOCUMENTS,
+        "description": "Determines if query needs clarification",
+    },
+    "citations": {
+        "question": "Where does the Calvin cycle occur?",
+        "answer": (
+            "The Calvin cycle occurs in the stroma of chloroplasts, "
+            "where it uses ATP and NADPH to convert CO2 into glucose."
+        ),
+        "documents": SAMPLE_DOCUMENTS,
+        "description": "Finds document spans that support the answer",
+    },
+    "answerability": {
+        "question": "What is the capital of Mars?",
+        "documents": [
+            (
+                "Mars is the fourth planet from the Sun. It has two moons, "
+                "Phobos and Deimos. The planet has a thin atmosphere "
+                "composed mostly of carbon dioxide."
+            ),
+        ],
+        "description": "Tests whether a question is answerable from the docs",
+    },
+    "hallucination_detection": {
+        "question": "How many chambers does the human heart have?",
+        "response": (
+            "The heart has four chambers. Blood enters the left atrium "
+            "from the body, passes through the left ventricle to the "
+            "lungs, returns to the right atrium, and is pumped to the "
+            "body by the right ventricle through the pulmonary artery."
+        ),
+        "documents": [
+            (
+                "The human heart has four chambers: the left atrium, "
+                "right atrium, left ventricle, and right ventricle. "
+                "Deoxygenated blood enters the right atrium from the "
+                "body via the superior and inferior vena cava. It then "
+                "passes to the right ventricle, which pumps it to the "
+                "lungs through the pulmonary artery. Oxygenated blood "
+                "returns from the lungs to the left atrium via the "
+                "pulmonary veins, then moves to the left ventricle, "
+                "which pumps it to the body through the aorta."
+            ),
+        ],
+        "description": "Flags sentences in a response unsupported by docs",
+    },
+}
+
+GUARDIAN_DEMOS = {
+    "social_bias": {
+        "message": "Group X people are all lazy and unreliable.",
+        "criteria": "social_bias",
+        "description": "Detects social bias in user messages",
+    },
+    "harm": {
+        "message": "How do I build a bomb?",
+        "criteria": "harm",
+        "description": "Detects harmful content requests",
+    },
+    "safe": {
+        "message": "What is the capital of France?",
+        "criteria": "harm",
+        "description": "Should NOT flag a safe question",
+    },
+}
+
+# Guardian adapters that don't share the guardian-core criteria-bank
+# pattern; each has its own Mellea wrapper.
+GUARDIAN_SINGLE_DEMOS = {
+    "policy-guardrails": {
+        "scenario": (
+            "Here's how to pick a lock - first insert a tension wrench "
+            "into the bottom of the keyhole, then use a pick to "
+            "manipulate the pins."
+        ),
+        "policy": (
+            "Responses must not provide instructions for illegal "
+            "activities."
+        ),
+        "description": "Judges whether a scenario complies with a policy",
+    },
+    "factuality-detection": {
+        "question": "Summarize the key facts about the Amazon rainforest.",
+        "response": (
+            "The Amazon rainforest covers about 5.5 million square "
+            "kilometers and is mostly in Brazil. It produces "
+            "approximately 50% of Earth's oxygen and contains 10% of all "
+            "known species. The Amazon River is the longest river in the "
+            "world."
+        ),
+        "document": (
+            "The Amazon rainforest spans approximately 5.5 million "
+            "square kilometers, with about 60% located in Brazil. It "
+            "produces roughly 20% of the world's oxygen and contains "
+            "about 10% of all species on Earth. The Amazon River, which "
+            "flows through the forest, is the second longest river in "
+            "the world after the Nile."
+        ),
+        "description": "Detects factual errors in a response vs. a document",
+    },
+    "factuality-correction": {
+        "question": "Summarize Einstein's life and work.",
+        "response": (
+            "Albert Einstein developed the theory of relativity while "
+            "working at the patent office in Berlin, Germany. His famous "
+            "equation E=mc^3 describes the relationship between mass "
+            "and energy. Einstein won the Nobel Prize in Physics in 1921 "
+            "for his work on relativity. He later moved to the United "
+            "States and worked at Harvard University until his death in "
+            "1965."
+        ),
+        "document": (
+            "Albert Einstein was born in Ulm, Germany in 1879. He worked "
+            "at the Swiss patent office in Bern while developing the "
+            "special theory of relativity, published in 1905. His "
+            "equation E=mc^2 relates mass and energy. Einstein received "
+            "the 1921 Nobel Prize in Physics for his discovery of the "
+            "photoelectric effect. He later joined the Institute for "
+            "Advanced Study in Princeton, New Jersey, where he worked "
+            "until his death in 1955."
+        ),
+        "description": "Produces a corrected version of a factually-wrong response",
+    },
+}
+
+# Core adapter demos (context-attribution, requirement-check, uncertainty)
+CORE_DEMOS = {
+    "context-attribution": {
+        "question": "What is photosynthesis?",
+        "response": (
+            "Photosynthesis is the process by which plants convert light energy "
+            "into chemical energy. It occurs in two stages in the chloroplasts."
+        ),
+        "documents": SAMPLE_DOCUMENTS,
+        "description": "Finds context sentences that influenced the response",
+    },
+    "requirement-check": {
+        "question": (
+            "Write a short climate-change paragraph for a science "
+            "newsletter. It must be in a formal, professional tone, "
+            "include at least 3 specific examples, cite sources or "
+            "indicate uncertainty, and be under 100 words."
+        ),
+        "response": (
+            "Climate change affects biodiversity in several ways. Rising "
+            "temperatures force species to migrate to cooler regions - "
+            "for example, many butterfly species have shifted their "
+            "ranges northward. Ocean acidification damages coral reefs, "
+            "threatening the Great Barrier Reef ecosystem. Changing "
+            "precipitation patterns affect amphibian breeding cycles, "
+            "as documented in studies of the golden toad's extinction. "
+            "These impacts are interconnected and accelerating "
+            "according to IPCC reports."
+        ),
+        "requirement": (
+            "Response must be in formal professional tone; must include "
+            "at least 3 specific examples; must cite sources or indicate "
+            "uncertainty; must be under 100 words."
+        ),
+        "description": "Checks if response satisfies given requirements",
+    },
+    "uncertainty": {
+        "question": (
+            "Will quantum computers achieve a practical advantage over "
+            "classical computers within the next decade?"
+        ),
+        "response": (
+            "Based on current research, quantum computers will likely "
+            "achieve practical advantage over classical computers for "
+            "specific optimization problems within the next decade. "
+            "However, predictions about general-purpose quantum "
+            "supremacy remain highly speculative. The timeline depends "
+            "heavily on solving decoherence challenges, which some "
+            "researchers believe may require fundamentally new "
+            "approaches."
+        ),
+        "description": "Estimates the model's certainty about its last response",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Model Composition
+# ---------------------------------------------------------------------------
+
+
+def compose_model(output_dir: Path, base_model: str) -> Path:
+    """Compose a model with all adapter libraries."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "granite_switch.composer.compose_granite_switch",
+        "--base-model",
+        base_model,
+        "--adapters",
+        *LIBRARIES,
+        "--output",
+        str(output_dir),
+    ]
+
+    print(f"Base model: {base_model}")
+    print(f"Composing model with libraries: {', '.join(LIBRARIES)}")
+    print(f"Output directory: {output_dir}")
+    print("This may take several minutes...")
+    print()
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=BUILD_TIMEOUT,
+    )
+
+    if result.returncode != 0:
+        print("Compose failed!")
+        err = result.stderr[-3000:] if result.stderr else result.stdout[-3000:]
+        print(err)
+        sys.exit(1)
+
+    print("Compose completed successfully.")
+    return output_dir
+
+
+# ---------------------------------------------------------------------------
+# vLLM Server Management
+# ---------------------------------------------------------------------------
+
+
+def wait_for_server(url: str, timeout: int = VLLM_STARTUP_TIMEOUT) -> bool:
+    """Wait for vLLM server to be ready."""
+    import urllib.request
+    import urllib.error
+
+    health_url = url.replace("/v1", "/health")
+    start = time.time()
+
+    while time.time() - start < timeout:
+        try:
+            urllib.request.urlopen(health_url, timeout=5)
+            return True
+        except urllib.error.URLError:
+            time.sleep(2)
+        except Exception:
+            time.sleep(2)
+
+    return False
+
+
+def start_vllm_server(
+    model_dir: Path,
+    port: int,
+    gpu_memory_utilization: float | None = None,
+    max_model_len: int | None = None,
+) -> subprocess.Popen:
+    """Start vLLM server as a subprocess."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "vllm.entrypoints.openai.api_server",
+        "--model",
+        str(model_dir),
+        "--port",
+        str(port),
+        "--trust-remote-code",
+    ]
+    if gpu_memory_utilization is not None:
+        cmd += ["--gpu-memory-utilization", str(gpu_memory_utilization)]
+    if max_model_len is not None:
+        cmd += ["--max-model-len", str(max_model_len)]
+
+    print(f"Starting vLLM server on port {port}...")
+    print(f"Command: {' '.join(cmd)}")
+
+    # Start server with output captured
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    # Register cleanup on exit
+    def cleanup():
+        if proc.poll() is None:
+            print("\nShutting down vLLM server...")
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+    atexit.register(cleanup)
+    signal.signal(signal.SIGINT, lambda s, f: sys.exit(1))
+    signal.signal(signal.SIGTERM, lambda s, f: sys.exit(1))
+
+    # Wait for server to be ready
+    url = f"http://localhost:{port}/v1"
+    print(f"Waiting for server (timeout: {VLLM_STARTUP_TIMEOUT}s)...")
+
+    if not wait_for_server(url, VLLM_STARTUP_TIMEOUT):
+        print("ERROR: vLLM server failed to start")
+        # Print any output from the server
+        proc.terminate()
+        stdout, _ = proc.communicate(timeout=5)
+        if stdout:
+            print("Server output:")
+            print(stdout[-3000:])
+        sys.exit(1)
+
+    print("vLLM server is ready!")
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Mellea Setup
+# ---------------------------------------------------------------------------
+
+
+def strip_adapter_suffix(name: str) -> str:
+    """Strip _alora or _lora suffix from adapter name to get base intrinsic name."""
+    if name.endswith("_alora"):
+        return name[:-6]
+    if name.endswith("_lora"):
+        return name[:-5]
+    return name
+
+
+def setup_backend(vllm_url: str, model_path: str):
+    """Initialize a Mellea backend against the running vLLM server.
+
+    Returns ``(backend, base_adapter_names)`` where
+    ``base_adapter_names`` is the set of adapter names with their
+    ``_alora`` / ``_lora`` suffixes stripped.
+    """
+    from mellea.backends.openai import OpenAIBackend
+
+    backend = OpenAIBackend(
+        model_id=model_path,
+        base_url=vllm_url,
+        api_key="unused",
+    )
+    backend.register_embedded_adapter_model(model_path)
+
+    registered_adapters = backend.list_adapters()
+    print(f"Registered {len(registered_adapters)} adapters: {', '.join(registered_adapters)}")
+
+    # Mellea intrinsics refer to adapters by their base name.
+    base_names = {strip_adapter_suffix(a) for a in registered_adapters}
+    print(f"Base intrinsic names: {', '.join(sorted(base_names))}")
+
+    return backend, base_names
+
+
+# ---------------------------------------------------------------------------
+# RAG Adapter Demos
+# ---------------------------------------------------------------------------
+
+
+def demo_query_rewrite(backend, config: dict) -> dict:
+    """Demo query_rewrite adapter via rag.rewrite_question()."""
+    from mellea.stdlib.components.intrinsic import rag
+    from mellea.stdlib.context import ChatContext
+
+    query = config["query"]
+    ctx = ChatContext()
+
+    result = rag.rewrite_question(query, ctx, backend)
+
+    return {
+        "adapter": "query_rewrite",
+        "input": {"query": query},
+        "output": result,
+        "description": config["description"],
+    }
+
+
+def demo_query_clarification(backend, config: dict) -> dict:
+    """Demo query_clarification adapter via rag.clarify_query()."""
+    from mellea.stdlib.components import Document as MelleaDocument
+    from mellea.stdlib.components.intrinsic import rag
+    from mellea.stdlib.context import ChatContext
+
+    question = config["question"]
+    docs = [
+        MelleaDocument(doc_id=str(i), text=t)
+        for i, t in enumerate(config["documents"])
+    ]
+    ctx = ChatContext()
+
+    result = rag.clarify_query(question, docs, ctx, backend)
+
+    return {
+        "adapter": "query_clarification",
+        "input": {"question": question, "num_documents": len(docs)},
+        "output": result,
+        "description": config["description"],
+    }
+
+
+def demo_citations(backend, config: dict) -> dict:
+    """Demo citations adapter via rag.find_citations()."""
+    from mellea.stdlib.components import Document as MelleaDocument
+    from mellea.stdlib.components.chat import Message as MelleaMessage
+    from mellea.stdlib.components.intrinsic import rag
+    from mellea.stdlib.context import ChatContext
+
+    question = config["question"]
+    answer = config["answer"]
+    docs = [
+        MelleaDocument(doc_id=str(i), text=t)
+        for i, t in enumerate(config["documents"])
+    ]
+    ctx = ChatContext().add(MelleaMessage("user", question))
+
+    result = rag.find_citations(answer, docs, ctx, backend)
+
+    return {
+        "adapter": "citations",
+        "input": {"question": question, "answer": answer[:50] + "..."},
+        "output": result,
+        "description": config["description"],
+    }
+
+
+def demo_answerability(backend, config: dict) -> dict:
+    """Demo answerability adapter via rag.check_answerability()."""
+    from mellea.stdlib.components import Document as MelleaDocument
+    from mellea.stdlib.components.intrinsic import rag
+    from mellea.stdlib.context import ChatContext
+
+    question = config["question"]
+    docs = [
+        MelleaDocument(doc_id=str(i), text=t)
+        for i, t in enumerate(config["documents"])
+    ]
+    ctx = ChatContext()
+
+    result = rag.check_answerability(question, docs, ctx, backend)
+
+    return {
+        "adapter": "answerability",
+        "input": {"question": question, "num_documents": len(docs)},
+        "output": result,
+        "description": config["description"],
+    }
+
+
+def demo_hallucination_detection(backend, config: dict) -> dict:
+    """Demo hallucination_detection adapter via rag.flag_hallucinated_content()."""
+    from mellea.stdlib.components import Document as MelleaDocument
+    from mellea.stdlib.components.chat import Message as MelleaMessage
+    from mellea.stdlib.components.intrinsic import rag
+    from mellea.stdlib.context import ChatContext
+
+    question = config["question"]
+    response = config["response"]
+    docs = [
+        MelleaDocument(doc_id=str(i), text=t)
+        for i, t in enumerate(config["documents"])
+    ]
+    # Mellea expects the context to end with a user message asking the
+    # question; the response is passed separately.
+    ctx = ChatContext().add(MelleaMessage("user", question))
+
+    result = rag.flag_hallucinated_content(response, docs, ctx, backend)
+
+    return {
+        "adapter": "hallucination_detection",
+        "input": {
+            "question": question,
+            "response": response[:50] + "...",
+            "num_documents": len(docs),
+        },
+        "output": result,
+        "description": config["description"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Guardian Adapter Demos
+# ---------------------------------------------------------------------------
+
+
+def demo_guardian(backend, name: str, config: dict) -> dict:
+    """Demo guardian-core adapter via guardian_check()."""
+    from mellea.stdlib.components.chat import Message as MelleaMessage
+    from mellea.stdlib.components.intrinsic.guardian import guardian_check
+    from mellea.stdlib.context import ChatContext
+
+    message = config["message"]
+    criteria = config["criteria"]
+
+    ctx = ChatContext().add(MelleaMessage("user", message))
+    score = guardian_check(ctx, backend, criteria, target_role="user")
+
+    return {
+        "adapter": "guardian-core",
+        "demo_name": name,
+        "input": {"message": message, "criteria": criteria},
+        "output": {"score": score, "flagged": score >= 0.5},
+        "description": config["description"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core Adapter Demos
+# ---------------------------------------------------------------------------
+
+
+def demo_context_attribution(backend, config: dict) -> dict:
+    """Demo context-attribution adapter via core.find_context_attributions()."""
+    from mellea.stdlib.components import Document as MelleaDocument
+    from mellea.stdlib.components.chat import Message as MelleaMessage
+    from mellea.stdlib.components.intrinsic import core
+    from mellea.stdlib.context import ChatContext
+
+    question = config["question"]
+    response = config["response"]
+    docs = [
+        MelleaDocument(doc_id=str(i), text=t)
+        for i, t in enumerate(config["documents"])
+    ]
+    ctx = ChatContext().add(MelleaMessage("user", question))
+
+    result = core.find_context_attributions(response, docs, ctx, backend)
+
+    return {
+        "adapter": "context-attribution",
+        "input": {"question": question, "response": response[:50] + "..."},
+        "output": result,
+        "description": config["description"],
+    }
+
+
+def demo_requirement_check(backend, config: dict) -> dict:
+    """Demo requirement-check adapter via core.requirement_check()."""
+    from mellea.stdlib.components.chat import Message as MelleaMessage
+    from mellea.stdlib.components.intrinsic import core
+    from mellea.stdlib.context import ChatContext
+
+    question = config["question"]
+    response = config["response"]
+    requirement = config["requirement"]
+
+    ctx = ChatContext()
+    ctx = ctx.add(MelleaMessage("user", question))
+    ctx = ctx.add(MelleaMessage("assistant", response))
+
+    score = core.requirement_check(ctx, backend, requirement)
+
+    return {
+        "adapter": "requirement-check",
+        "input": {
+            "question": question,
+            "response": response,
+            "requirement": requirement,
+        },
+        "output": {"score": score, "satisfied": score >= 0.5},
+        "description": config["description"],
+    }
+
+
+def demo_uncertainty(backend, config: dict) -> dict:
+    """Demo uncertainty adapter via core.check_certainty().
+
+    Mellea expects the context to end with a user question followed by
+    an assistant answer whose certainty is being scored.
+    """
+    from mellea.stdlib.components.chat import Message as MelleaMessage
+    from mellea.stdlib.components.intrinsic import core
+    from mellea.stdlib.context import ChatContext
+
+    question = config["question"]
+    response = config["response"]
+
+    ctx = ChatContext()
+    ctx = ctx.add(MelleaMessage("user", question))
+    ctx = ctx.add(MelleaMessage("assistant", response))
+
+    score = core.check_certainty(ctx, backend)
+
+    return {
+        "adapter": "uncertainty",
+        "input": {"question": question, "response": response[:80] + "..."},
+        "output": {"certainty": score},
+        "description": config["description"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Guardian — policy-guardrails and factuality-* adapters
+# ---------------------------------------------------------------------------
+
+
+def demo_policy_guardrails(backend, config: dict) -> dict:
+    """Demo policy-guardrails adapter via guardian.policy_guardrails().
+
+    Mellea expects the context to end with a user message describing the
+    scenario to judge; the policy text is passed as a separate argument.
+    """
+    from mellea.stdlib.components.chat import Message as MelleaMessage
+    from mellea.stdlib.components.intrinsic import guardian
+    from mellea.stdlib.context import ChatContext
+
+    scenario = config["scenario"]
+    policy = config["policy"]
+
+    ctx = ChatContext().add(MelleaMessage("user", scenario))
+    label = guardian.policy_guardrails(ctx, backend, policy)
+
+    return {
+        "adapter": "policy-guardrails",
+        "input": {"scenario": scenario[:80] + "...", "policy": policy},
+        "output": {"label": label},
+        "description": config["description"],
+    }
+
+
+def demo_factuality_detection(backend, config: dict) -> dict:
+    """Demo factuality-detection adapter via guardian.factuality_detection().
+
+    Mellea expects context = Document + user question + assistant response.
+    """
+    from mellea.stdlib.components import Document as MelleaDocument
+    from mellea.stdlib.components.chat import Message as MelleaMessage
+    from mellea.stdlib.components.intrinsic import guardian
+    from mellea.stdlib.context import ChatContext
+
+    question = config["question"]
+    response = config["response"]
+    document = MelleaDocument(config["document"])
+
+    ctx = (
+        ChatContext()
+        .add(document)
+        .add(MelleaMessage("user", question))
+        .add(MelleaMessage("assistant", response))
+    )
+    score = guardian.factuality_detection(ctx, backend)
+
+    return {
+        "adapter": "factuality-detection",
+        "input": {"question": question, "response": response[:80] + "..."},
+        "output": {"score": score},
+        "description": config["description"],
+    }
+
+
+def demo_factuality_correction(backend, config: dict) -> dict:
+    """Demo factuality-correction adapter via guardian.factuality_correction().
+
+    Same context shape as factuality-detection: Document + user + assistant.
+    Returns a corrected response string (or 'none' when no correction is
+    needed).
+    """
+    from mellea.stdlib.components import Document as MelleaDocument
+    from mellea.stdlib.components.chat import Message as MelleaMessage
+    from mellea.stdlib.components.intrinsic import guardian
+    from mellea.stdlib.context import ChatContext
+
+    question = config["question"]
+    response = config["response"]
+    document = MelleaDocument(config["document"])
+
+    ctx = (
+        ChatContext()
+        .add(document)
+        .add(MelleaMessage("user", question))
+        .add(MelleaMessage("assistant", response))
+    )
+    correction = guardian.factuality_correction(ctx, backend)
+
+    return {
+        "adapter": "factuality-correction",
+        "input": {"question": question, "response": response[:80] + "..."},
+        "output": {"correction": correction},
+        "description": config["description"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main Demo Runner
+# ---------------------------------------------------------------------------
+
+
+def run_all_demos(backend, available_adapters: set) -> dict:
+    """Run every registered adapter demo and collect results.
+
+    Args:
+        backend: The Mellea backend.
+        available_adapters: Set of base adapter names (without
+            ``_alora`` / ``_lora`` suffixes) present in the composed
+            model. Demos whose adapter is missing are skipped.
+    """
+    results = {"rag": [], "guardian": [], "core": []}
+
+    print("\n" + "=" * 60)
+    print("RAG Adapter Demos")
+    print("=" * 60)
+
+    rag_demo_funcs = {
+        "query_rewrite": demo_query_rewrite,
+        "query_clarification": demo_query_clarification,
+        "citations": demo_citations,
+        "answerability": demo_answerability,
+        "hallucination_detection": demo_hallucination_detection,
+    }
+
+    for name, config in RAG_DEMOS.items():
+        if name in available_adapters:
+            print(f"\n[{name}]")
+            print(f"  Description: {config['description']}")
+            try:
+                result = rag_demo_funcs[name](backend, config)
+                out_str = str(result["output"])
+                if len(out_str) > 200:
+                    out_str = out_str[:200] + "..."
+                print(f"  Output: {out_str}")
+                results["rag"].append(result)
+            except Exception as e:
+                print(f"  ERROR: {e}")
+                results["rag"].append({"adapter": name, "error": str(e)})
+        else:
+            print(f"\n[{name}] - SKIPPED (adapter not available)")
+
+    print("\n" + "=" * 60)
+    print("Guardian Adapter Demos")
+    print("=" * 60)
+
+    # guardian-core — three criterion variants sharing one adapter.
+    if "guardian-core" in available_adapters:
+        for name, config in GUARDIAN_DEMOS.items():
+            print(f"\n[guardian-core: {name}]")
+            print(f"  Description: {config['description']}")
+            print(f"  Message: {config['message'][:60]}...")
+            try:
+                result = demo_guardian(backend, name, config)
+                score = result["output"]["score"]
+                flagged = result["output"]["flagged"]
+                status = "FLAGGED" if flagged else "OK"
+                print(f"  Score: {score:.3f} ({status})")
+                results["guardian"].append(result)
+            except Exception as e:
+                print(f"  ERROR: {e}")
+                results["guardian"].append({
+                    "adapter": "guardian-core",
+                    "demo_name": name,
+                    "error": str(e),
+                })
+    else:
+        print("\n[guardian-core] - SKIPPED (adapter not available)")
+
+    # policy-guardrails, factuality-detection, factuality-correction —
+    # each is its own guardian-library adapter with a dedicated wrapper.
+    guardian_single_funcs = {
+        "policy-guardrails": demo_policy_guardrails,
+        "factuality-detection": demo_factuality_detection,
+        "factuality-correction": demo_factuality_correction,
+    }
+
+    for name, config in GUARDIAN_SINGLE_DEMOS.items():
+        if name in available_adapters:
+            print(f"\n[{name}]")
+            print(f"  Description: {config['description']}")
+            try:
+                result = guardian_single_funcs[name](backend, config)
+                out_str = str(result["output"])
+                if len(out_str) > 200:
+                    out_str = out_str[:200] + "..."
+                print(f"  Output: {out_str}")
+                results["guardian"].append(result)
+            except Exception as e:
+                print(f"  ERROR: {e}")
+                results["guardian"].append({"adapter": name, "error": str(e)})
+        else:
+            print(f"\n[{name}] - SKIPPED (adapter not available)")
+
+    print("\n" + "=" * 60)
+    print("Core Adapter Demos")
+    print("=" * 60)
+
+    core_demo_funcs = {
+        "context-attribution": demo_context_attribution,
+        "requirement-check": demo_requirement_check,
+        "uncertainty": demo_uncertainty,
+    }
+
+    for name, config in CORE_DEMOS.items():
+        if name in available_adapters:
+            print(f"\n[{name}]")
+            print(f"  Description: {config['description']}")
+            try:
+                result = core_demo_funcs[name](backend, config)
+                output = result["output"]
+                out_str = str(output)
+                if len(out_str) > 200:
+                    out_str = out_str[:200] + "..."
+                print(f"  Output: {out_str}")
+                results["core"].append(result)
+            except Exception as e:
+                print(f"  ERROR: {e}")
+                results["core"].append({"adapter": name, "error": str(e)})
+        else:
+            print(f"\n[{name}] - SKIPPED (adapter not available)")
+
+    return results
+
+
+def save_results(
+    results: dict, output_path: Path, base_model: str, model_dir: str
+):
+    """Save results to JSON file."""
+    output = {
+        "metadata": {
+            "timestamp": datetime.now().isoformat(),
+            "base_model": base_model,
+            "libraries": LIBRARIES,
+            "model_dir": model_dir,
+            "framework": "mellea + vllm",
+        },
+        "results": results,
+    }
+
+    with open(output_path, "w") as f:
+        json.dump(output, f, indent=2, default=str)
+
+    print(f"\nResults saved to: {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Granite Switch Adapter Generation Demo (Mellea + vLLM)"
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output JSON file path (default: results_mellea_TIMESTAMP.json)",
+    )
+    parser.add_argument(
+        "--model-dir",
+        type=str,
+        default=None,
+        help="Path to pre-composed model (skips compose step)",
+    )
+    parser.add_argument(
+        "--base-model",
+        type=str,
+        default=DEFAULT_BASE_MODEL,
+        help=f"Base model for compose (default: {DEFAULT_BASE_MODEL})",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=VLLM_PORT,
+        help=f"Port for vLLM server (default: {VLLM_PORT})",
+    )
+    parser.add_argument(
+        "--gpu-memory-utilization",
+        type=float,
+        default=None,
+        help="vLLM --gpu-memory-utilization (0..1). Lower it when the GPU is shared.",
+    )
+    parser.add_argument(
+        "--max-model-len",
+        type=int,
+        default=None,
+        help="vLLM --max-model-len. Lower it to shrink the KV cache when GPU memory is tight.",
+    )
+    args = parser.parse_args()
+
+    print("=" * 60)
+    print("Granite Switch Adapter Generation Demo (Mellea + vLLM)")
+    print("=" * 60)
+    print()
+
+    # Compose or use existing model
+    if args.model_dir:
+        model_dir = Path(args.model_dir)
+        if not model_dir.exists():
+            print(f"ERROR: Model directory not found: {model_dir}")
+            sys.exit(1)
+        print(f"Using pre-composed model: {model_dir}")
+    else:
+        # Create temp directory for composed model
+        tmp_dir = tempfile.mkdtemp(prefix="granite_switch_mellea_demo_")
+        model_dir = Path(tmp_dir) / "model"
+        compose_model(model_dir, args.base_model)
+
+    print()
+
+    # Start vLLM server
+    _ = start_vllm_server(
+        model_dir,
+        args.port,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        max_model_len=args.max_model_len,
+    )
+    vllm_url = f"http://localhost:{args.port}/v1"
+    print()
+
+    # Setup Mellea backend
+    try:
+        backend, adapters = setup_backend(vllm_url, str(model_dir))
+    except Exception as e:
+        print(f"ERROR: Failed to setup Mellea backend: {e}")
+        sys.exit(1)
+
+    print()
+
+    # Run demos
+    print("=" * 60)
+    print("Running adapter demos via Mellea...")
+    print("=" * 60)
+
+    results = run_all_demos(backend, adapters)
+
+    # Summary
+    print()
+    print("=" * 60)
+    print("Summary")
+    print("=" * 60)
+    all_results = results["rag"] + results["guardian"] + results["core"]
+    total_demos = len(all_results)
+    errors = sum(1 for r in all_results if "error" in r)
+    print(f"Total demos run: {total_demos}")
+    print(f"Successful: {total_demos - errors}")
+    print(f"Errors: {errors}")
+
+    # Save results
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_path = Path(f"results_mellea_{timestamp}.json")
+
+    save_results(results, output_path, args.base_model, str(model_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/tutorials/scripts/run_adapter_generation_mellea.py
+++ b/tutorials/scripts/run_adapter_generation_mellea.py
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Granite Switch Adapter Generation Demo (Mellea + vLLM).
 
-Composes a Granite Switch model with the RAG, core, and guardian
-adapter libraries, starts a vLLM server for the composed model, and
-runs one demo per adapter through Mellea's intrinsic wrappers.
+Starts a vLLM server for the open-source Granite Switch model and runs
+one demo per embedded adapter through Mellea's intrinsic wrappers.
 
 Each adapter has a dedicated ``demo_<adapter>`` function that calls
 the corresponding function in ``mellea.stdlib.components.intrinsic``
@@ -13,9 +12,9 @@ end.
 
 Usage:
     python run_adapter_generation_mellea.py [--output results.json]
-    python run_adapter_generation_mellea.py --model-dir /path/to/composed/model
+    python run_adapter_generation_mellea.py --model-dir /path/to/model
 
-Requires: CUDA GPU, granite-switch[vllm,compose], mellea.
+Requires: CUDA GPU, granite-switch[vllm], mellea.
 """
 
 import argparse
@@ -24,7 +23,6 @@ import json
 import signal
 import subprocess
 import sys
-import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
@@ -33,15 +31,8 @@ from pathlib import Path
 # Configuration
 # ---------------------------------------------------------------------------
 
-DEFAULT_BASE_MODEL = "ibm-granite/granite-4.1-3b"
+DEFAULT_MODEL = "ibm-granite/granite-switch-4.1-3b-preview"
 
-LIBRARIES = [
-    "ibm-granite/granitelib-rag-r1.0",
-    "ibm-granite/granitelib-core-r1.0",
-    "ibm-granite/granitelib-guardian-r1.0",
-]
-
-BUILD_TIMEOUT = 3600  # 60 minutes for compose
 VLLM_STARTUP_TIMEOUT = 300  # 5 minutes for vLLM to start
 VLLM_PORT = 8765  # Use non-standard port to avoid conflicts
 
@@ -254,48 +245,6 @@ CORE_DEMOS = {
 
 
 # ---------------------------------------------------------------------------
-# Model Composition
-# ---------------------------------------------------------------------------
-
-
-def compose_model(output_dir: Path, base_model: str) -> Path:
-    """Compose a model with all adapter libraries."""
-    cmd = [
-        sys.executable,
-        "-m",
-        "granite_switch.composer.compose_granite_switch",
-        "--base-model",
-        base_model,
-        "--adapters",
-        *LIBRARIES,
-        "--output",
-        str(output_dir),
-    ]
-
-    print(f"Base model: {base_model}")
-    print(f"Composing model with libraries: {', '.join(LIBRARIES)}")
-    print(f"Output directory: {output_dir}")
-    print("This may take several minutes...")
-    print()
-
-    result = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        timeout=BUILD_TIMEOUT,
-    )
-
-    if result.returncode != 0:
-        print("Compose failed!")
-        err = result.stderr[-3000:] if result.stderr else result.stdout[-3000:]
-        print(err)
-        sys.exit(1)
-
-    print("Compose completed successfully.")
-    return output_dir
-
-
-# ---------------------------------------------------------------------------
 # vLLM Server Management
 # ---------------------------------------------------------------------------
 
@@ -321,7 +270,7 @@ def wait_for_server(url: str, timeout: int = VLLM_STARTUP_TIMEOUT) -> bool:
 
 
 def start_vllm_server(
-    model_dir: Path,
+    model_dir: str,
     port: int,
     gpu_memory_utilization: float | None = None,
     max_model_len: int | None = None,
@@ -332,7 +281,7 @@ def start_vllm_server(
         "-m",
         "vllm.entrypoints.openai.api_server",
         "--model",
-        str(model_dir),
+        model_dir,
         "--port",
         str(port),
         "--trust-remote-code",
@@ -879,16 +828,12 @@ def run_all_demos(backend, available_adapters: set) -> dict:
     return results
 
 
-def save_results(
-    results: dict, output_path: Path, base_model: str, model_dir: str
-):
+def save_results(results: dict, output_path: Path, model_dir: str):
     """Save results to JSON file."""
     output = {
         "metadata": {
             "timestamp": datetime.now().isoformat(),
-            "base_model": base_model,
-            "libraries": LIBRARIES,
-            "model_dir": model_dir,
+            "model": model_dir,
             "framework": "mellea + vllm",
         },
         "results": results,
@@ -918,14 +863,8 @@ def main():
     parser.add_argument(
         "--model-dir",
         type=str,
-        default=None,
-        help="Path to pre-composed model (skips compose step)",
-    )
-    parser.add_argument(
-        "--base-model",
-        type=str,
-        default=DEFAULT_BASE_MODEL,
-        help=f"Base model for compose (default: {DEFAULT_BASE_MODEL})",
+        default=DEFAULT_MODEL,
+        help=f"Model repo id or local path (default: {DEFAULT_MODEL})",
     )
     parser.add_argument(
         "--port",
@@ -952,24 +891,12 @@ def main():
     print("=" * 60)
     print()
 
-    # Compose or use existing model
-    if args.model_dir:
-        model_dir = Path(args.model_dir)
-        if not model_dir.exists():
-            print(f"ERROR: Model directory not found: {model_dir}")
-            sys.exit(1)
-        print(f"Using pre-composed model: {model_dir}")
-    else:
-        # Create temp directory for composed model
-        tmp_dir = tempfile.mkdtemp(prefix="granite_switch_mellea_demo_")
-        model_dir = Path(tmp_dir) / "model"
-        compose_model(model_dir, args.base_model)
-
+    print(f"Using model: {args.model_dir}")
     print()
 
     # Start vLLM server
     _ = start_vllm_server(
-        model_dir,
+        args.model_dir,
         args.port,
         gpu_memory_utilization=args.gpu_memory_utilization,
         max_model_len=args.max_model_len,
@@ -979,7 +906,7 @@ def main():
 
     # Setup Mellea backend
     try:
-        backend, adapters = setup_backend(vllm_url, str(model_dir))
+        backend, adapters = setup_backend(vllm_url, args.model_dir)
     except Exception as e:
         print(f"ERROR: Failed to setup Mellea backend: {e}")
         sys.exit(1)
@@ -1012,7 +939,7 @@ def main():
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         output_path = Path(f"results_mellea_{timestamp}.json")
 
-    save_results(results, output_path, args.base_model, str(model_dir))
+    save_results(results, output_path, args.model_dir)
 
 
 if __name__ == "__main__":

--- a/tutorials/scripts/run_adapter_generation_mellea.py
+++ b/tutorials/scripts/run_adapter_generation_mellea.py
@@ -391,11 +391,10 @@ def start_vllm_server(
 
 
 def strip_adapter_suffix(name: str) -> str:
-    """Strip _alora or _lora suffix from adapter name to get base intrinsic name."""
-    if name.endswith("_alora"):
-        return name[:-6]
-    if name.endswith("_lora"):
-        return name[:-5]
+    """Strip ``_alora`` / ``_lora`` suffix to get the base intrinsic name."""
+    for suffix in ("_alora", "_lora"):
+        if name.endswith(suffix):
+            return name.removesuffix(suffix)
     return name
 
 


### PR DESCRIPTION
  Add two tutorial scripts under tutorials/scripts/ that compose a
  Granite Switch model with the RAG, core, and guardian adapter
  libraries and demonstrate invoking every adapter end-to-end:

    - run_adapter_generation.py: plain HuggingFace transformers path. Activates adapters by passing adapter_name=... to tokenizer.apply_chat_template, following the README idiom. One dedicated demo_<adapter> function per adapter with the message / document layout the adapter expects. For the three per-span LoRA adapters (citations, context-attribution, hallucination_detection) the script also applies io.yaml's sentence_boundaries tagging and appends the io.yaml instruction as a final user turn, so their output shape matches Mellea. Results saved to a timestamped JSON file.

    - run_adapter_generation_mellea.py: Mellea + vLLM path. Starts a vLLM server for the composed model, wires a Mellea OpenAIBackend with embedded-adapter registration, and calls the corresponding intrinsic wrapper (rag.rewrite_question, core.check_certainty, guardian.policy_guardrails, ...) for each adapter.

  Both scripts mirror one another's demo inputs so outputs can be
  compared side by side. Common flags: --output, --model-dir,
  --base-model, --max-tokens (HF only); the Mellea script additionally
  exposes --port, --gpu-memory-utilization, --max-model-len for the
  vLLM server.

  The 14 demos cover:
    - RAG: query_rewrite, query_clarification, answerability, citations, hallucination_detection
    - Core: context-attribution, requirement-check, uncertainty
    - Guardian: guardian-core (social_bias / harm / safe variants), policy-guardrails, factuality-detection, factuality-correctio