### PR TITLE
Respect --technology-filter in selective download

### DIFF
--- a/src/granite_switch/composer/adapter_discovery.py
+++ b/src/granite_switch/composer/adapter_discovery.py
@@ -339,6 +339,7 @@ def _build_allow_patterns(
     target_model_name: Optional[str] = None,
     include_adapters: Optional[List[str]] = None,
     exclude_adapters: Optional[List[str]] = None,
+    technology_filter: Optional[str] = None,
 ) -> Optional[List[str]]:
     """Build ``allow_patterns`` for selective ``snapshot_download``.
 
@@ -346,7 +347,10 @@ def _build_allow_patterns(
     fnmatch-based include/exclude filtering and target model constraints to
     construct download patterns.  When both adapter names and target model
     are known, also resolves the preferred technology (alora > lora) so
-    only the needed technology variant is downloaded.
+    only the needed technology variant is downloaded.  If ``technology_filter``
+    is set, it overrides the alora>lora preference so downstream discovery
+    (which respects the same filter) does not reject adapters whose alora
+    variant was downloaded while the caller asked for lora only.
 
     Returns:
         List of glob patterns, or ``None`` if no filtering is possible.
@@ -371,6 +375,13 @@ def _build_allow_patterns(
     if adapter_names and target_model_name:
         patterns = []
         for name in adapter_names:
+            if technology_filter:
+                # Caller explicitly asked for a specific technology; download
+                # only that variant so discovery doesn't later skip the adapter.
+                patterns.append(
+                    f"{name}/{target_model_name}/{technology_filter}/**"
+                )
+                continue
             tech = _resolve_technology(repo_id, name, target_model_name)
             if tech:
                 patterns.append(f"{name}/{target_model_name}/{tech}/**")
@@ -441,6 +452,7 @@ def resolve_repo_path(
     target_model_name: Optional[str] = None,
     include_adapters: Optional[List[str]] = None,
     exclude_adapters: Optional[List[str]] = None,
+    technology_filter: Optional[str] = None,
 ) -> str:
     """Resolve a local path or HuggingFace repo ID to a local directory.
 
@@ -455,6 +467,9 @@ def resolve_repo_path(
         include_adapters: Only download adapters matching these fnmatch
             patterns.
         exclude_adapters: Skip adapters matching these fnmatch patterns.
+        technology_filter: If set to ``"alora"`` or ``"lora"``, download only
+            that technology variant (aligns with ``discover_adapters``'
+            ``technology_filter`` so both phases agree).
 
     Returns:
         Absolute local path to the directory.
@@ -471,13 +486,15 @@ def resolve_repo_path(
 
         # Build selective download patterns
         allow_patterns = None
-        if target_model_name or include_adapters or exclude_adapters:
+        if (target_model_name or include_adapters or exclude_adapters
+                or technology_filter):
             try:
                 allow_patterns = _build_allow_patterns(
                     path_or_repo,
                     target_model_name=target_model_name,
                     include_adapters=include_adapters,
                     exclude_adapters=exclude_adapters,
+                    technology_filter=technology_filter,
                 )
                 if allow_patterns:
                     print(f"  Selective download patterns: {allow_patterns}")

--- a/src/granite_switch/composer/compose_granite_switch.py
+++ b/src/granite_switch/composer/compose_granite_switch.py
@@ -608,6 +608,7 @@ def build():
                     target_model_name=args.target_model,
                     include_adapters=args.include_adapters,
                     exclude_adapters=args.exclude_adapters,
+                    technology_filter=args.technology_filter,
                 )
             except Exception as e:
                 print(f"Failed to resolve {entry}: {e}")

--- a/tests/composer/test_selective_download.py
+++ b/tests/composer/test_selective_download.py
@@ -153,6 +153,23 @@ class TestBuildAllowPatterns:
             )
         assert patterns == ["answerability/granite-4.1-3b/alora/**"]
 
+    def test_technology_filter_overrides_alora_preference(self, default_tree):
+        """``technology_filter='lora'`` must force lora paths even for
+        adapters that have an alora variant — otherwise discovery (which
+        also respects the filter) drops them and the final model is missing
+        adapters."""
+        with patch("huggingface_hub.list_repo_tree", side_effect=default_tree):
+            patterns = _build_allow_patterns(
+                "org/repo",
+                target_model_name="granite-4.1-3b",
+                technology_filter="lora",
+            )
+        assert patterns == [
+            "answerability/granite-4.1-3b/lora/**",
+            "citations/granite-4.1-3b/lora/**",
+            "query_rewrite/granite-4.1-3b/lora/**",
+        ]
+
 
 # ---------------------------------------------------------------------------
 # resolve_repo_path — integration with snapshot_download


### PR DESCRIPTION
When both phases of compose disagree on technology, adapters get silently skipped: the download phase was hardcoded to prefer alora > lora, so with `--technology-filter lora` it downloaded alora variants for any adapter that had both. The later discovery phase (which honored the filter) rejected them, producing a model missing adapters with no error.

Thread `technology_filter` through `resolve_repo_path` and `_build_allow_patterns`. When set, the pattern builder skips `_resolve_technology` and emits `{name}/{target}/{technology_filter}/**` directly, so the download and discovery phases agree on which variants to keep.

Validated end-to-end against ibm-granite/granitelib-{rag,core,guardian}-r1.0: `--technology-filter lora` now yields 12 adapters (was 2), and `--technology-filter alora` yields 9 adapters, both across all three repos.

Added a unit test that fails without the fix.