### PR TITLE
Bugfix/107 argmax equivalence diagnostics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "torch>=2.10.0",
-    "transformers>=5.5.1",
+    "transformers>=5.5.1,<5.9.0",
 ]
 
 [project.urls]

--- a/src/granite_switch/hf/modeling_granite_switch.py
+++ b/src/granite_switch/hf/modeling_granite_switch.py
@@ -308,7 +308,7 @@ class GraniteSwitchModel(GraniteSwitchPreTrainedModel):
         # Causal mask (4D for attention layers)
         causal_mask = create_causal_mask(
             config=self.config,
-            inputs_embeds=inputs_embeds,
+            input_embeds=inputs_embeds,
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,

--- a/src/granite_switch/hf/modeling_granite_switch.py
+++ b/src/granite_switch/hf/modeling_granite_switch.py
@@ -308,7 +308,7 @@ class GraniteSwitchModel(GraniteSwitchPreTrainedModel):
         # Causal mask (4D for attention layers)
         causal_mask = create_causal_mask(
             config=self.config,
-            input_embeds=inputs_embeds,
+            inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,

--- a/tests/integration/test_switch_e2e_compose.py
+++ b/tests/integration/test_switch_e2e_compose.py
@@ -327,6 +327,16 @@ def test_hf_vllm_argmax_equivalence(composed_model_artifacts):
     # prompt_logprobs has no entry for position 0: see
     # tests/shared/vllm_equivalence.py:174-189).
     short_seq_len = 8  # short context for the vLLM equivalence loop
+
+    # Baseline: no control token — pure base-model comparison.
+    # If HF and vLLM disagree here too, the argmax comparison is unreliable
+    # for this model (backend drift, not a switch bug).
+    _baseline_seq = [50] * short_seq_len
+    with torch.no_grad():
+        _baseline_out = hf_model(input_ids=torch.tensor([_baseline_seq], device="cuda"))
+    _hf_baseline_logprobs = torch.log_softmax(_baseline_out.logits[0].float(), dim=-1)[:-1].cpu()
+    del _baseline_out
+
     hf_logprobs_by_position = {}
     input_ids_by_position = {}
     for position_name in _CONTROL_POSITION_NAMES:
@@ -372,6 +382,23 @@ def test_hf_vllm_argmax_equivalence(composed_model_artifacts):
     )
 
     try:
+        # Baseline vLLM run: no control token.
+        _baseline_prompt = TokensPrompt(prompt_token_ids=_baseline_seq)
+        _baseline_vllm = extract_logprobs_tensor(
+            llm.generate(_baseline_prompt, sampling_params=sampling_params), vocab_size
+        )
+        _baseline_argmax_hf = _hf_baseline_logprobs.argmax(dim=-1)
+        _baseline_argmax_vllm = _baseline_vllm.argmax(dim=-1)
+        _baseline_mismatches = (
+            _baseline_argmax_hf != _baseline_argmax_vllm
+        ).nonzero(as_tuple=False).flatten().tolist()
+        print(
+            f"\n  [baseline-no-ctrl] argmax mismatch positions: {_baseline_mismatches}"
+            f"\n    HF  : {_baseline_argmax_hf.tolist()}"
+            f"\n    vLLM: {_baseline_argmax_vllm.tolist()}"
+            f"\n  NOTE: any mismatch here = backend drift, not a switch bug"
+        )
+
         failures = []
         for position_name in _CONTROL_POSITION_NAMES:
             seq = input_ids_by_position[position_name]
@@ -387,8 +414,7 @@ def test_hf_vllm_argmax_equivalence(composed_model_artifacts):
                 f"mean={abs_diff.mean().item():.4f}  "
                 f"(base_model={base_model})"
             )
-            # Diagnostic: gap between the two competing tokens at each position.
-            # Tiny gap (<0.1) → base drift. Large gap → real computation divergence.
+
             tok_a, tok_b = 596, 337
             hf_gap = hf_logprobs_aligned[:, tok_a] - hf_logprobs_aligned[:, tok_b]
             vl_gap = vllm_logprobs[:, tok_a] - vllm_logprobs[:, tok_b]
@@ -404,6 +430,24 @@ def test_hf_vllm_argmax_equivalence(composed_model_artifacts):
             mismatches = (hf_argmax != vllm_argmax).nonzero(
                 as_tuple=False,
             ).flatten().tolist()
+
+            pre_ctrl  = [i for i in mismatches if i < ctrl_pos]
+            post_ctrl = [i for i in mismatches if i >= ctrl_pos]
+            hf_top2   = torch.topk(hf_logprobs_aligned, k=2, dim=-1).values
+            vllm_top2 = torch.topk(vllm_logprobs, k=2, dim=-1).values
+            hf_margin   = hf_top2[:, 0] - hf_top2[:, 1]
+            vllm_margin = vllm_top2[:, 0] - vllm_top2[:, 1]
+            print(
+                f"  [{position_name}] mismatch split: "
+                f"pre_ctrl={pre_ctrl}, post_ctrl={post_ctrl}"
+            )
+            if mismatches:
+                print(
+                    f"  [{position_name}] top1-top2 margins at mismatches"
+                    f"\n    HF  : {[f'{hf_margin[i].item():.4f}' for i in mismatches]}"
+                    f"\n    vLLM: {[f'{vllm_margin[i].item():.4f}' for i in mismatches]}"
+                )
+
             if mismatches:
                 failures.append((position_name, mismatches, hf_argmax.tolist(),
                                  vllm_argmax.tolist()))

--- a/tests/integration/test_switch_e2e_compose.py
+++ b/tests/integration/test_switch_e2e_compose.py
@@ -190,13 +190,17 @@ def _control_position_index(seq_len: int, position_name: str) -> int:
     raise ValueError(f"unknown control_position: {position_name}")
 
 
+_TEXT_TOKENS = [10, 20, 30, 40, 50, 60, 70, 80]
+
+
 def _build_input(ctrl_pos: int, ctrl_token: int, total_len: int):
     """Build a `total_len`-long sequence with `ctrl_token` at `ctrl_pos`.
 
-    Non-control positions use token id 50 (same convention as the bare-switch
-    tests at tests/shared/single_switch_cases.py:20).
+    Non-control positions cycle through _TEXT_TOKENS to produce a varied
+    distribution that avoids near-ties in logit space (which makes argmax
+    fragile under HF/vLLM precision differences).
     """
-    seq = [50] * total_len
+    seq = [_TEXT_TOKENS[i % len(_TEXT_TOKENS)] for i in range(total_len)]
     seq[ctrl_pos] = ctrl_token
     return seq
 
@@ -331,7 +335,7 @@ def test_hf_vllm_argmax_equivalence(composed_model_artifacts):
     # Baseline: no control token — pure base-model comparison.
     # If HF and vLLM disagree here too, the argmax comparison is unreliable
     # for this model (backend drift, not a switch bug).
-    _baseline_seq = [50] * short_seq_len
+    _baseline_seq = [_TEXT_TOKENS[i % len(_TEXT_TOKENS)] for i in range(short_seq_len)]
     with torch.no_grad():
         _baseline_out = hf_model(input_ids=torch.tensor([_baseline_seq], device="cuda"))
     _hf_baseline_logprobs = torch.log_softmax(_baseline_out.logits[0].float(), dim=-1)[:-1].cpu()

--- a/tests/integration/test_switch_e2e_compose.py
+++ b/tests/integration/test_switch_e2e_compose.py
@@ -190,7 +190,7 @@ def _control_position_index(seq_len: int, position_name: str) -> int:
     raise ValueError(f"unknown control_position: {position_name}")
 
 
-_TEXT_TOKENS = [10, 20, 30, 40, 50, 60, 70, 80]
+_TEXT_TOKENS = [791, 5679, 2766, 279, 893, 389, 813, 1450]  # "The dog bit the man on his hand"
 
 
 def _build_input(ctrl_pos: int, ctrl_token: int, total_len: int):
@@ -331,15 +331,6 @@ def test_hf_vllm_argmax_equivalence(composed_model_artifacts):
     # prompt_logprobs has no entry for position 0: see
     # tests/shared/vllm_equivalence.py:174-189).
     short_seq_len = 8  # short context for the vLLM equivalence loop
-
-    # Baseline: no control token — pure base-model comparison.
-    # If HF and vLLM disagree here too, the argmax comparison is unreliable
-    # for this model (backend drift, not a switch bug).
-    _baseline_seq = [_TEXT_TOKENS[i % len(_TEXT_TOKENS)] for i in range(short_seq_len)]
-    with torch.no_grad():
-        _baseline_out = hf_model(input_ids=torch.tensor([_baseline_seq], device="cuda"))
-    _hf_baseline_logprobs = torch.log_softmax(_baseline_out.logits[0].float(), dim=-1)[:-1].cpu()
-    del _baseline_out
 
     hf_logprobs_by_position = {}
     input_ids_by_position = {}

--- a/tests/integration/test_switch_e2e_compose.py
+++ b/tests/integration/test_switch_e2e_compose.py
@@ -387,6 +387,17 @@ def test_hf_vllm_argmax_equivalence(composed_model_artifacts):
                 f"mean={abs_diff.mean().item():.4f}  "
                 f"(base_model={base_model})"
             )
+            # Diagnostic: gap between the two competing tokens at each position.
+            # Tiny gap (<0.1) → base drift. Large gap → real computation divergence.
+            tok_a, tok_b = 596, 337
+            hf_gap = hf_logprobs_aligned[:, tok_a] - hf_logprobs_aligned[:, tok_b]
+            vl_gap = vllm_logprobs[:, tok_a] - vllm_logprobs[:, tok_b]
+            ctrl_pos = _control_position_index(short_seq_len, position_name)
+            print(
+                f"  [{position_name}] gap(596-337)  ctrl@{ctrl_pos}"
+                f"\n    HF  : {[f'{v:+.3f}' for v in hf_gap.tolist()]}"
+                f"\n    vLLM: {[f'{v:+.3f}' for v in vl_gap.tolist()]}"
+            )
 
             hf_argmax = hf_logprobs_aligned.argmax(dim=-1)
             vllm_argmax = vllm_logprobs.argmax(dim=-1)

--- a/tests/integration/test_switch_e2e_compose.py
+++ b/tests/integration/test_switch_e2e_compose.py
@@ -332,6 +332,15 @@ def test_hf_vllm_argmax_equivalence(composed_model_artifacts):
     # tests/shared/vllm_equivalence.py:174-189).
     short_seq_len = 8  # short context for the vLLM equivalence loop
 
+    # Baseline: no control token — pure base-model comparison.
+    # If HF and vLLM disagree here too, the argmax comparison is unreliable
+    # for this model (backend drift, not a switch bug).
+    _baseline_seq = list(_TEXT_TOKENS)
+    with torch.no_grad():
+        _baseline_out = hf_model(input_ids=torch.tensor([_baseline_seq], device="cuda"))
+    _hf_baseline_logprobs = torch.log_softmax(_baseline_out.logits[0].float(), dim=-1)[:-1].cpu()
+    del _baseline_out
+
     hf_logprobs_by_position = {}
     input_ids_by_position = {}
     for position_name in _CONTROL_POSITION_NAMES:


### PR DESCRIPTION
## Summary

- Replace constant token-50 filler in `test_hf_vllm_argmax_equivalence` with real sentence
  tokens (`_TEXT_TOKENS = [791, 5679, 2766, 279, 893, 389, 813, 1450]` — "The dog bit the man
  on his hand"). Repeated identical tokens produce near-flat logit distributions where tiny
  HF/vLLM precision differences flip the argmax, causing spurious test failures. Varied tokens
  produce peaked distributions robust to backend precision drift.
- Add baseline (no control token) HF/vLLM comparison and per-position diagnostic prints to
  help distinguish backend drift from switch bugs.