### PR TITLE
Update Python version requirement to align with mellea 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Granite Switch: Composable model building"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "torch>=2.10.0",
     "transformers>=5.5.1,<5.9.0",


### PR DESCRIPTION
Updates requires-python from >=3.10,<3.14 to >=3.11,<3.14 to match the actual requirement of the mellea==0.6.0 dependency, which requires Python >=3.11. This prevents unsatisfiable dependency errors for Python 3.10 users and provides a clear error message upfront.

Fixes #69