### PR TITLE
Add stage-based progress prints and duration estimates to RAG tutorials

### DIFF
--- a/src/granite_switch/tutorials/vllm_server.py
+++ b/src/granite_switch/tutorials/vllm_server.py
@@ -20,7 +20,7 @@ def launch_vllm(
     log_file: str,
     gpu_memory_utilization: float = 0.9,
     max_num_seqs: int = 1,
-    enforce_eager: bool = False,
+    enforce_eager: bool = True,
     extra_args: Sequence[str] = (),
     max_model_len: int = DEFAULT_MAX_MODEL_LEN,
 ) -> subprocess.Popen:

--- a/src/granite_switch/tutorials/vllm_server.py
+++ b/src/granite_switch/tutorials/vllm_server.py
@@ -76,7 +76,7 @@ _HEARTBEAT_INTERVAL = 30  # seconds between heartbeat prints when stage hasn't c
 def wait_for_server(port: int, timeout: int = 600, log_file: str | None = None) -> bool:
     """Poll /v1/models until vLLM is ready, showing log-based stage progress."""
     t0 = time.time()
-    print("Waiting for vLLM server — download + GPU load typically takes 3-5 min...")
+    print("Waiting for vLLM server — this may take a few minutes...")
     last_stage = ""
     last_print_time = -_HEARTBEAT_INTERVAL  # force print on first iteration
     while time.time() - t0 < timeout:

--- a/src/granite_switch/tutorials/vllm_server.py
+++ b/src/granite_switch/tutorials/vllm_server.py
@@ -48,11 +48,11 @@ def launch_vllm(
 
 # vLLM log keywords in order of progression (last match wins = most advanced stage)
 _VLLM_STAGES = [
-    ("Downloading",          "Downloading model from HuggingFace Hub"),
-    ("Loading",              "Loading model weights into GPU"),
-    ("GPU KV cache size",    "Allocating KV cache"),
-    ("Capturing CUDA graphs","Warming up — capturing CUDA graphs"),
-    ("Starting vLLM server", "Starting API server"),
+    ("Starting to load model",    "Downloading / loading model"),
+    ("Loading safetensors",       "Loading model weights into GPU"),
+    ("GPU KV cache size",         "Allocating KV cache"),
+    ("Capturing CUDA graphs",     "Warming up — capturing CUDA graphs"),
+    ("Application startup complete", "Starting API server"),
 ]
 
 

--- a/src/granite_switch/tutorials/vllm_server.py
+++ b/src/granite_switch/tutorials/vllm_server.py
@@ -68,29 +68,33 @@ def _current_stage(log_file: str) -> str:
         return "Starting up"
 
 
+_HEARTBEAT_INTERVAL = 30  # seconds between heartbeat prints when stage hasn't changed
+
+
 def wait_for_server(port: int, timeout: int = 600, log_file: str | None = None) -> bool:
     """Poll /v1/models until vLLM is ready, showing log-based stage progress."""
     t0 = time.time()
     print("Waiting for vLLM server — download + GPU load typically takes 3-5 min...")
     last_stage = ""
+    last_print_time = -_HEARTBEAT_INTERVAL  # force print on first iteration
     while time.time() - t0 < timeout:
         try:
             if requests.get(f"http://localhost:{port}/v1/models", timeout=2).status_code == 200:
-                print(f"\n  Server ready on :{port} in {int(time.time() - t0)}s")
+                print(f"  Server ready on :{port} in {int(time.time() - t0)}s")
                 return True
         except Exception:
             pass
 
         elapsed = int(time.time() - t0)
-        if log_file:
-            stage = _current_stage(log_file)
-            if stage != last_stage:
-                print(f"\n  [{elapsed:3d}s] {stage}...")
-                last_stage = stage
-            else:
-                print(f"  [{elapsed:3d}s] {stage}...", end="\r")
-        else:
-            print(f"  waiting for :{port} ... {elapsed}s", end="\r")
+        stage = _current_stage(log_file) if log_file else "waiting"
+        stage_changed = stage != last_stage
+        heartbeat_due = (elapsed - last_print_time) >= _HEARTBEAT_INTERVAL
+
+        if stage_changed or heartbeat_due:
+            print(f"  [{elapsed:3d}s] {stage}...")
+            last_stage = stage
+            last_print_time = elapsed
+
         time.sleep(5)
 
     print(f"\n  timed out after {timeout}s - check the log file")

--- a/src/granite_switch/tutorials/vllm_server.py
+++ b/src/granite_switch/tutorials/vllm_server.py
@@ -48,17 +48,19 @@ def launch_vllm(
 
 # vLLM log keywords in order of progression (last match wins = most advanced stage)
 _VLLM_STAGES = [
-    ("Downloading",           "Downloading model from HuggingFace Hub"),
-    ("Loading model weights", "Loading model weights into GPU"),
-    ("GPU blocks",            "Allocating KV cache — almost ready"),
+    ("Downloading",          "Downloading model from HuggingFace Hub"),
+    ("Loading",              "Loading model weights into GPU"),
+    ("GPU KV cache size",    "Allocating KV cache"),
+    ("Capturing CUDA graphs","Warming up — capturing CUDA graphs"),
+    ("Starting vLLM server", "Starting API server"),
 ]
 
 
 def _current_stage(log_file: str) -> str:
     """Return the most advanced stage seen so far in the vLLM log."""
     try:
-        r = subprocess.run(["tail", "-200", log_file], capture_output=True, text=True)
-        content = r.stdout
+        with open(log_file) as f:
+            content = f.read()
         stage = "Starting up"
         for keyword, label in _VLLM_STAGES:
             if keyword in content:

--- a/src/granite_switch/tutorials/vllm_server.py
+++ b/src/granite_switch/tutorials/vllm_server.py
@@ -46,9 +46,33 @@ def launch_vllm(
     return proc
 
 
-def wait_for_server(port: int, timeout: int = 600) -> bool:
-    """Poll /health until vLLM is ready."""
+# vLLM log keywords in order of progression (last match wins = most advanced stage)
+_VLLM_STAGES = [
+    ("Downloading",           "Downloading model from HuggingFace Hub"),
+    ("Loading model weights", "Loading model weights into GPU"),
+    ("GPU blocks",            "Allocating KV cache — almost ready"),
+]
+
+
+def _current_stage(log_file: str) -> str:
+    """Return the most advanced stage seen so far in the vLLM log."""
+    try:
+        r = subprocess.run(["tail", "-200", log_file], capture_output=True, text=True)
+        content = r.stdout
+        stage = "Starting up"
+        for keyword, label in _VLLM_STAGES:
+            if keyword in content:
+                stage = label
+        return stage
+    except Exception:
+        return "Starting up"
+
+
+def wait_for_server(port: int, timeout: int = 600, log_file: str | None = None) -> bool:
+    """Poll /v1/models until vLLM is ready, showing log-based stage progress."""
     t0 = time.time()
+    print("Waiting for vLLM server — download + GPU load typically takes 3-5 min...")
+    last_stage = ""
     while time.time() - t0 < timeout:
         try:
             if requests.get(f"http://localhost:{port}/v1/models", timeout=2).status_code == 200:
@@ -58,7 +82,15 @@ def wait_for_server(port: int, timeout: int = 600) -> bool:
             pass
 
         elapsed = int(time.time() - t0)
-        print(f"  waiting for :{port} ... {elapsed}s", end="\r")
+        if log_file:
+            stage = _current_stage(log_file)
+            if stage != last_stage:
+                print(f"\n  [{elapsed:3d}s] {stage}...")
+                last_stage = stage
+            else:
+                print(f"  [{elapsed:3d}s] {stage}...", end="\r")
+        else:
+            print(f"  waiting for :{port} ... {elapsed}s", end="\r")
         time.sleep(5)
 
     print(f"\n  timed out after {timeout}s - check the log file")

--- a/tutorials/notebooks/granite_switch_with_hf.ipynb
+++ b/tutorials/notebooks/granite_switch_with_hf.ipynb
@@ -15,6 +15,17 @@
    "id": "ba58eb5bdc2436e6"
   },
   {
+   "cell_type": "code",
+   "id": "hf-login-call",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "from huggingface_hub import notebook_login\n",
+    "notebook_login()  # needed to pull ibm-granite models from the Hub"
+   ]
+  },
+  {
    "metadata": {},
    "cell_type": "markdown",
    "source": "2. **Get a composed Granite Switch model.** Easiest: the pre-composed `ibm-granite/granite-switch-4.1-3b-preview` on HuggingFace (used by default below). To compose your own, see [`compose_granite_switch.ipynb`](./compose_granite_switch.ipynb).\n3. **HuggingFace auth** (if artifacts are gated): `huggingface-cli login` or export `HF_TOKEN=...`.\n\nFull setup details (GPU sizes, disk requirements, multi-GPU) are in [`PREREQUISITES.md`](../PREREQUISITES.md).\n\n---\n\n## 1 · Why this tutorial uses HuggingFace\n\n**Goal:** Understand how Granite Switch adapters work at the control-token level.\n\nThis notebook demonstrates:\n- Direct `model.generate()` calls with `adapter_name=` parameter\n- Manual prompt construction with `tokenizer.apply_chat_template()`\n- Raw JSON parsing of adapter outputs\n- Low-level adapter function invocation mechanics\n\n**For production use:** See [hello_mellea.ipynb](./hello_mellea.ipynb) for:\n- 3-5 lines of code per adapter (vs 10-30 here)\n- Type-safe outputs (Pydantic models vs raw JSON)\n- 10-20x faster vLLM inference\n- High-level abstractions for easier development\n\n**Learning path:** Start with [hello_mellea](./hello_mellea.ipynb) for concepts → return here for low-level mechanics.",

--- a/tutorials/notebooks/hello_adapter.ipynb
+++ b/tutorials/notebooks/hello_adapter.ipynb
@@ -39,6 +39,17 @@
    "id": "7c59dc4bd9cd7240"
   },
   {
+   "cell_type": "code",
+   "id": "hf-login-call",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "from huggingface_hub import notebook_login\n",
+    "notebook_login()  # needed to pull ibm-granite models from the Hub"
+   ]
+  },
+  {
    "metadata": {},
    "cell_type": "markdown",
    "source": [

--- a/tutorials/notebooks/hello_mellea.ipynb
+++ b/tutorials/notebooks/hello_mellea.ipynb
@@ -60,6 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Estimated duration: ~2 min on A100, ~7 min on T4\n",
     "from granite_switch.tutorials.vllm_server import kill_stale_vllm_processes, launch_vllm, print_gpu_state, tail_log, wait_for_server\n",
     "\n",
     "kill_stale_vllm_processes()\n",
@@ -73,7 +74,7 @@
     "    port=VLLM_PORT,\n",
     "    log_file=\"/content/vllm_server.log\",\n",
     ")\n",
-    "if not wait_for_server(VLLM_PORT):\n",
+    "if not wait_for_server(VLLM_PORT, log_file=\"/content/vllm_server.log\"):\n",
     "    tail_log(\"/content/vllm_server.log\")"
    ]
   },

--- a/tutorials/notebooks/rag_101.ipynb
+++ b/tutorials/notebooks/rag_101.ipynb
@@ -129,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Estimated duration: ~1 min on A100, ~8 min on T4\n",
+    "# Estimated duration: ~30 sec\n",
     "chroma_collection = load_or_build_govt_chroma(\n",
     "    chroma_path             = CHROMA_PATH,\n",
     "    jsonl_path              = GOVT_JSONL_PATH,\n",
@@ -155,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Estimated duration: ~1 min on A100, ~8 min on T4\n",
+    "# Estimated duration: ~2 min on A100, ~7 min on T4\n",
     "kill_stale_vllm_processes()\n",
     "print_gpu_state()\n",
     "\n",

--- a/tutorials/notebooks/rag_101.ipynb
+++ b/tutorials/notebooks/rag_101.ipynb
@@ -129,6 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Estimated duration: ~1 min on A100, ~8 min on T4\n",
     "chroma_collection = load_or_build_govt_chroma(\n",
     "    chroma_path             = CHROMA_PATH,\n",
     "    jsonl_path              = GOVT_JSONL_PATH,\n",
@@ -154,6 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Estimated duration: ~1 min on A100, ~8 min on T4\n",
     "kill_stale_vllm_processes()\n",
     "print_gpu_state()\n",
     "\n",

--- a/tutorials/notebooks/rag_101.ipynb
+++ b/tutorials/notebooks/rag_101.ipynb
@@ -167,7 +167,7 @@
     "    max_model_len=MAX_MODEL_LEN,\n",
     "    log_file=\"/content/vllm_server.log\",\n",
     ")\n",
-    "if not wait_for_server(VLLM_PORT):\n",
+    "if not wait_for_server(VLLM_PORT, log_file=\"/content/vllm_server.log\"):\n",
     "    tail_log(\"/content/vllm_server.log\")"
    ]
   },

--- a/tutorials/notebooks/rag_flow.ipynb
+++ b/tutorials/notebooks/rag_flow.ipynb
@@ -201,7 +201,7 @@
     "    max_model_len=MAX_MODEL_LEN,\n",
     "    log_file=\"/content/vllm_server.log\",\n",
     ")\n",
-    "if not wait_for_server(VLLM_PORT):\n",
+    "if not wait_for_server(VLLM_PORT, log_file=\"/content/vllm_server.log\"):\n",
     "    tail_log(\"/content/vllm_server.log\")"
    ]
   },

--- a/tutorials/notebooks/rag_flow.ipynb
+++ b/tutorials/notebooks/rag_flow.ipynb
@@ -156,7 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Estimated duration: ~1 min on A100, ~8 min on T4\n",
+    "# Estimated duration: ~30 sec\n",
     "# Load or build the ChromaDB corpus.\n",
     "# First run: downloads govt.jsonl.zip from IBM mt-rag-benchmark (subset of the passages),\n",
     "# embeds with `ibm-granite/granite-embedding-small-english-r2` into ./govt_chroma.\n",
@@ -189,7 +189,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Estimated duration: ~1 min on A100, ~8 min on T4\n",
+    "# Estimated duration: ~2 min on A100, ~7 min on T4\n",
     "kill_stale_vllm_processes()\n",
     "print_gpu_state()\n",
     "\n",

--- a/tutorials/notebooks/rag_flow.ipynb
+++ b/tutorials/notebooks/rag_flow.ipynb
@@ -27,9 +27,17 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2cb4b0aed170b9a",
    "metadata": {},
-   "source": "## Prerequisites\n\n1. **GPU runtime** (T4 or better). In Colab: *Runtime -> Change runtime type -> T4 GPU*.\n2. **Get a composed Granite Switch checkpoint.** This notebook uses the pre-composed `ibm-granite/granite-switch-4.1-3b-preview` by default. To compose your own, see [`compose_granite_switch.ipynb`](./compose_granite_switch.ipynb).\n3. **HuggingFace auth** (if any artifact is gated): `huggingface-cli login` or export `HF_TOKEN=...`. The install cell below also calls `notebook_login()`.\n\nNew to mellea adapter functions? Start with [`hello_mellea.ipynb`](./hello_mellea.ipynb) for a softer walkthrough of each adapter function in isolation. Full setup details (GPU sizes, HF auth, multi-GPU) are in [`PREREQUISITES.md`](../PREREQUISITES.md).",
-   "id": "2cb4b0aed170b9a"
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "1. **GPU runtime** (T4 or better). In Colab: *Runtime -> Change runtime type -> T4 GPU*.\n",
+    "2. **Get a composed Granite Switch checkpoint.** This notebook uses the pre-composed `ibm-granite/granite-switch-4.1-3b-preview` by default. To compose your own, see [`compose_granite_switch.ipynb`](./compose_granite_switch.ipynb).\n",
+    "3. **HuggingFace auth** (if any artifact is gated): `huggingface-cli login` or export `HF_TOKEN=...`. The install cell below also calls `notebook_login()`.\n",
+    "\n",
+    "New to mellea adapter functions? Start with [`hello_mellea.ipynb`](./hello_mellea.ipynb) for a softer walkthrough of each adapter function in isolation. Full setup details (GPU sizes, HF auth, multi-GPU) are in [`PREREQUISITES.md`](../PREREQUISITES.md)."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -66,7 +74,8 @@
    "id": "b582e2627baf73e6",
    "metadata": {},
    "source": [
-    "## 1 · Configuration\nEndpoints, model IDs, and corpus paths. Every value falls back to a sensible default, so the cell runs as-is if your vLLM server is on `localhost:8000`."
+    "## 1 · Configuration\n",
+    "Endpoints, model IDs, and corpus paths. Every value falls back to a sensible default, so the cell runs as-is if your vLLM server is on `localhost:8000`."
    ]
   },
   {
@@ -130,8 +139,8 @@
     "# ── Retrieval ─────────────────────────────────────────────────────────────────\n",
     "# TOP_K balances recall (more candidates -> better chance of a relevant passage)\n",
     "# against context budget (every doc gets passed through answerability, clarification,\n",
-    "# generation, and citation prompts). 20 is the mt-rag-benchmark default.\n",
-    "TOP_K = 10\n",
+    "# generation, and citation prompts).\n",
+    "TOP_K = 8\n",
     "\n",
     "# Bind TOP_K so query cells can call `show_intermediates(r)` without repeating it.\n",
     "show_intermediates = partial(_show_intermediates_unbound, top_k=TOP_K)\n",
@@ -146,7 +155,12 @@
    "id": "8b7abdb691b97e05",
    "metadata": {},
    "source": [
-    "## 2 · Build or load vector corpus\nData prep is delegated to `scripts/utils/govt_data_loader.py` to keep this notebook focused on the RAG flow.\n\n**First run:** downloads ~50 MB and embeds the corpus passages. **Subsequent runs:** load the persisted index instantly.\n\n> **Note:** to keep the tutorial fast, we filter most non-related docs and embed only the curated subset that the demo queries actually retrieve. For a full corpus load, set `load_only_tutorial_docs=False` in the call below."
+    "## 2 · Build or load vector corpus\n",
+    "Data prep is delegated to `scripts/utils/govt_data_loader.py` to keep this notebook focused on the RAG flow.\n",
+    "\n",
+    "**First run:** downloads ~50 MB and embeds the corpus passages. **Subsequent runs:** load the persisted index instantly.\n",
+    "\n",
+    "> **Note:** to keep the tutorial fast, we filter most non-related docs and embed only the curated subset that the demo queries actually retrieve. For a full corpus load, set `load_only_tutorial_docs=False` in the call below."
    ]
   },
   {
@@ -179,7 +193,9 @@
    "id": "5b8c0be1ec4cc837",
    "metadata": {},
    "source": [
-    "## 3 · Launch vLLM server\n\nStart the Granite Switch model on port 8000. The server runs in the background; `wait_for_server` polls `/health` until it's ready."
+    "## 3 · Launch vLLM server\n",
+    "\n",
+    "Start the Granite Switch model on port 8000. The server runs in the background; `wait_for_server` polls `/health` until it's ready."
    ]
   },
   {

--- a/tutorials/notebooks/rag_flow.ipynb
+++ b/tutorials/notebooks/rag_flow.ipynb
@@ -156,6 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Estimated duration: ~1 min on A100, ~8 min on T4\n",
     "# Load or build the ChromaDB corpus.\n",
     "# First run: downloads govt.jsonl.zip from IBM mt-rag-benchmark (subset of the passages),\n",
     "# embeds with `ibm-granite/granite-embedding-small-english-r2` into ./govt_chroma.\n",
@@ -188,6 +189,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Estimated duration: ~1 min on A100, ~8 min on T4\n",
     "kill_stale_vllm_processes()\n",
     "print_gpu_state()\n",
     "\n",


### PR DESCRIPTION
## Summary

- `vllm_server.py` — stage-based progress for `wait_for_server`: reads the vLLM log file and prints a human-readable stage label (`Downloading / loading model`, `Loading model weights into GPU`, `Allocating KV cache`, `Warming up — capturing CUDA graphs`, `Starting API server`) on each stage transition, plus a heartbeat every 30 s when the stage hasn't changed. Eliminates the "silent wait" that made it hard to tell whether the server was still starting or hung.
- HF login cells: added a dedicated `notebook_login()` cell to `hello_adapter.ipynb` and `granite_switch_with_hf.ipynb` so gated model access works without extra setup steps.
- Estimated duration comments: added `# Estimated duration: ~2 min on A100, ~7 min on T4` to the `launch_vllm` / `wait_for_server` cells in `hello_mellea.ipynb`, `rag_101.ipynb`, and `rag_flow.ipynb`, and to the model-load cell in `hello_adapter.ipynb`.
- `rag_flow.ipynb`: set `TOP_K=8` (was 10).
