### PR TITLE
Make HF backend compatible with transformers 5.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.11,<3.14"
 dependencies = [
     "torch>=2.10.0",
-    "transformers>=5.5.1,<5.9.0",
+    "transformers>=5.5.1,<5.10.0",
 ]
 
 [project.urls]

--- a/src/granite_switch/hf/modeling_granite_switch.py
+++ b/src/granite_switch/hf/modeling_granite_switch.py
@@ -11,9 +11,15 @@ from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
+import transformers
+from packaging.version import parse as _parse_version
 from transformers.cache_utils import Cache, DynamicCache
 from transformers.generation import GenerationMixin
 from transformers.masking_utils import create_causal_mask
+
+# transformers 5.9.0 renamed `input_embeds` -> `inputs_embeds` and dropped the
+# unused `cache_position` kwarg in `create_causal_mask`.
+_TRANSFORMERS_GE_5_9 = _parse_version(transformers.__version__) >= _parse_version("5.9.0")
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.models.granitemoehybrid.modeling_granitemoehybrid import (
     GraniteMoeHybridMLP,
@@ -283,14 +289,18 @@ class GraniteSwitchModel(GraniteSwitchPreTrainedModel):
         mask_shape_proxy = inputs_embeds if inputs_embeds is not None else torch.empty(
             batch_size, seq_length, 1, device=device, dtype=embed_dtype
         )
-        causal_mask = create_causal_mask(
-            config=self.config,
-            input_embeds=mask_shape_proxy,
-            attention_mask=attention_mask,
-            cache_position=cache_position,
-            past_key_values=past_key_values,
-            position_ids=position_ids,
-        )
+        mask_kwargs = {
+            "config": self.config,
+            "attention_mask": attention_mask,
+            "past_key_values": past_key_values,
+            "position_ids": position_ids,
+        }
+        if _TRANSFORMERS_GE_5_9:
+            mask_kwargs["inputs_embeds"] = mask_shape_proxy
+        else:
+            mask_kwargs["input_embeds"] = mask_shape_proxy
+            mask_kwargs["cache_position"] = cache_position
+        causal_mask = create_causal_mask(**mask_kwargs)
 
         # The switch returns adapter_indices alongside modified_input_ids:
         # input_ids with each control token rewritten to its substitute id,


### PR DESCRIPTION
`transformers.masking_utils.create_causal_mask` changed signature in 5.9.0: the `input_embeds` kwarg was renamed to `inputs_embeds`, and `cache_position` was deprecated and removed (it had been unused).

Apply version-dispatch at the call site to keep working on 5.5–5.8 while supporting 5.9. The probe is module-level next to the existing transformers imports; the kwargs dict is inline at the single call site in modeling_granite_switch.py.

Verified 5.9 still only reads batch/seq-length/dtype/device from `inputs_embeds`, so the existing (B, S, 1) `mask_shape_proxy` stub stays valid — no other adjustments needed.

Bump pyproject constraint from `<5.9.0` to `<5.10.0` to allow installs on 5.9.x.

Refs #63