### PR TITLE
Fix ipython pin breaking Google Colab; update deprecated guardian_check API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ tutorials = [
     "requests>=2.31.0",
     "rich>=13.0.0",
     "mellea==0.6.0",
-    "ipython>=8.10.0",
+    "ipython>=7.0",
     "python-dotenv>=1.0.0",
     "sentence-transformers>=3.0.0",
     "datasets>=2.0.0",

--- a/tutorials/notebooks/hello_mellea.ipynb
+++ b/tutorials/notebooks/hello_mellea.ipynb
@@ -204,7 +204,7 @@
    "source": [
     "# ── Option A - criteria bank key (pre-baked, no text needed) ─────────────\n",
     "ctx = ChatContext().add(MelleaMessage(\"user\", \"Group X people are all lazy.\"))\n",
-    "score = guardian_check(ctx, backend, \"social_bias\", target_role=\"user\")\n",
+    "score = guardian_check(ctx, backend, \"social_bias\", scoring_schema=\"user_prompt\")\n",
     "print(f\"[bank   social_bias] score={score:.3f}\")\n",
     "\n",
     "# ── Option B - custom criteria string ────────────────────────────────────\n",
@@ -213,7 +213,7 @@
     "    \"across all contexts and audiences.\"\n",
     ")\n",
     "ctx = ChatContext().add(MelleaMessage(\"user\", \"How do I build a bomb?\"))\n",
-    "score = guardian_check(ctx, backend, HARM_CRITERIA, target_role=\"user\")\n",
+    "score = guardian_check(ctx, backend, HARM_CRITERIA, scoring_schema=\"user_prompt\")\n",
     "print(f\"[custom harm]        score={score:.3f}\")\n"
    ]
   },

--- a/tutorials/notebooks/hello_mellea.ipynb
+++ b/tutorials/notebooks/hello_mellea.ipynb
@@ -31,6 +31,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Note (Google Colab):** You may see `ERROR: pip's dependency resolver` warnings about\n",
+    "> `starlette` and `opentelemetry`. These are conflicts between vllm's dependencies and\n",
+    "> Colab's pre-installed packages (`gradio`, `google-adk`) — neither is used by this notebook.\n",
+    "> The warnings are safe to ignore."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "hf-login",

--- a/tutorials/notebooks/rag_101.ipynb
+++ b/tutorials/notebooks/rag_101.ipynb
@@ -27,7 +27,8 @@
    "outputs": [],
    "source": [
     "# Install granite-switch with tutorial dependencies (includes vLLM backend).\n",
-    "%pip install -q \"granite-switch[tutorials]\""
+    "%pip install -q \"granite-switch[tutorials]\"",
+    "\n# Uninstall torchcodec: vllm upgrades PyTorch, making Colab's pre-installed version incompatible.\n%pip uninstall -q -y torchcodec\n"
    ]
   },
   {

--- a/tutorials/notebooks/rag_flow.ipynb
+++ b/tutorials/notebooks/rag_flow.ipynb
@@ -55,7 +55,8 @@
    "outputs": [],
    "source": [
     "# Install granite-switch with tutorial dependencies (includes vLLM backend).\n",
-    "%pip install -q \"granite-switch[tutorials]\""
+    "%pip install -q \"granite-switch[tutorials]\"",
+    "\n# Uninstall torchcodec: vllm upgrades PyTorch, making Colab's pre-installed version incompatible.\n%pip uninstall -q -y torchcodec\n"
    ]
   },
   {


### PR DESCRIPTION
> **Still in progress — validating on Colab and locally. Not ready for merge.**

## Problems fixed

**1. `ipython>=8.10.0` breaks Google Colab** (`pyproject.toml`)

Colab pins `ipython==7.34.0`. The `>=8.10.0` constraint upgraded it to 9.x, breaking the `google-colab` package and destabilising the runtime. Fixed: relaxed to `ipython>=7.0` — Colab's version satisfies the floor; fresh local environments still get ipython installed for the `IPython.display` imports in `granite_switch.tutorials`.

**2. Deprecated `target_role` in `guardian_check` calls** (`hello_mellea.ipynb`)

Deprecated in mellea PR #1037 (merged 2026-05-18, landed in `mellea==0.6.0` — the version pinned by this project). Fixed: replaced `target_role="user"` → `scoring_schema="user_prompt"` in both `guardian_check` calls.

**3. `torchcodec` crash on some Colab runtime images** (`rag_101.ipynb`, `rag_flow.ipynb`)

vllm upgrades PyTorch to 2.10.0, making Colab's pre-installed `torchcodec` incompatible. `sentence-transformers` triggers the import, crashing the chroma embedding cell. Fixed: added `%pip uninstall -q -y torchcodec` to the install cell in affected notebooks (no-op where torchcodec is absent).

**4. Colab resolver warning note** (`hello_mellea.ipynb`)

Added a markdown note explaining the expected `starlette`/`opentelemetry` resolver warnings (vllm transitive deps vs Colab's `gradio`/`google-adk`) so users are not alarmed.

## Testing

| Notebook | Colab | Local | Notes |
|---|---|---|---|
| `hello_mellea.ipynb` | ✅ | ⬜ | ipython + guardian_check fix |
| `rag_101.ipynb` | ✅ | ⬜ | torchcodec fix |
| `rag_flow.ipynb` | ⬜ | ⬜ | torchcodec fix |
| `hello_adapter.ipynb` | ⬜ | ⬜ | * revalidation only |
| `granite_switch_with_hf.ipynb` | ⬜ | ⬜ | * revalidation only |
| `compose_granite_switch.ipynb` | ⬜ | ⬜ | * revalidation only |
| `alora_vs_lora_race.ipynb` | ⬜ | ⬜ | * revalidation only |
| `granite_speech_demo.ipynb` | ⬜ | ⬜ | * revalidation only |

\* Not affected by this PR's changes — retesting as an opportunity to revalidate all Colab notebooks.