### PR TITLE
Add OpenWiki documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+## OpenWiki
+
+This repository has documentation located in the /openwiki directory.
+
+Start here:
+- [OpenWiki quickstart](openwiki/quickstart.md)
+
+OpenWiki includes repository overview, architecture notes, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+When working in this repository, read the OpenWiki quickstart first, then follow its links to the relevant architecture, workflow, domain, operation, and testing notes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,3 +393,15 @@ When committing, **never sign as Claude** (per project instructions)
 ## License
 
 Apache-2.0 (as indicated by SPDX headers in source files)
+
+
+## OpenWiki
+
+This repository has documentation located in the /openwiki directory.
+
+Start here:
+- [OpenWiki quickstart](openwiki/quickstart.md)
+
+OpenWiki includes repository overview, architecture notes, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+When working in this repository, read the OpenWiki quickstart first, then follow its links to the relevant architecture, workflow, domain, operation, and testing notes.

--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,0 +1,7 @@
+{
+  "command": "init",
+  "model": "claude-opus-4.6",
+  "updatedAt": "2026-07-07T07:27:55.941Z",
+  "gitHead": "756f946640d571a5beef2a49d4cab6614c61f18a",
+  "snapshotHash": "b3Blbndpa2kvYXJj"
+}

--- a/openwiki/architecture/composer.md
+++ b/openwiki/architecture/composer.md
@@ -1,0 +1,100 @@
+# The Composer
+
+[← Overview](overview.md)
+
+**Source:** `src/granite_switch/composer/` (requires the `compose` extra).
+**CLI entry point:** `python -m granite_switch.composer.compose_granite_switch`.
+
+The composer combines a base Granite model with one or more LoRA/aLoRA adapters
+into a single deployable checkpoint that works with both backends unchanged.
+
+## Module responsibilities
+
+| Module | Role |
+|---|---|
+| `compose_granite_switch.py` | CLI, `build()` / `save_and_validate_model_artifacts()`, orchestration |
+| `compose_utils.py` | `GraniteSwitchComposer` — the programmatic API (`from_base_and_adapters`) |
+| `adapter_discovery.py` | Find adapters in HF repos / local dirs / YAML manifests; filter; selective download |
+| `adapter_loader.py` | Detect LoRA rank/alpha and which module groups are present |
+| `arch.py` | Architecture descriptors (`granite_dense_arch`, `granite_moe_hybrid_arch`); resolve base model → module layout |
+| `weight_transfer.py` | Transfer base weights (with fusion) and stack adapter weights |
+| `weight_remapper.py` | `AdapterRemapper` — map upstream PEFT names → Switch parameter names |
+| `tokenizer_setup.py` | Add control tokens, build the adapter-aware chat template |
+| `validator.py` | Post-build parameter validation |
+| `reporting/` | Model card, compose report, population table, adapter analysis |
+
+## The compose pipeline
+
+`GraniteSwitchComposer.from_base_and_adapters` (in `compose_utils.py`) runs these
+steps — read the docstring there for the authoritative list:
+
+1. **Resolve architecture** from the base model config (`resolve_arch`). Detects
+   dense vs MoE-hybrid layout.
+2. **Detect LoRA config** — per-adapter rank/alpha (`detect_lora_config`) and
+   which module groups each adapter targets (`detect_present_modules`).
+3. **Build `GraniteSwitchConfig`** — copy arch-required fields from base config,
+   prepend one **switch layer** at index 0 (bumps `num_hidden_layers` by 1 when
+   adapters are present), set switch/adapter params.
+4. **Create model** (`GraniteSwitchForCausalLM`), cast to config dtype.
+5. **Transfer base weights** (`transfer_base_weights`) with arch-driven fusion of
+   Q/K/V and gate/up projections.
+6. **Transfer adapter weights** (`transfer_adapter_weights`) — stack each
+   adapter's `lora_A`/`lora_B` into the switched tensors, pre-scaling `lora_B` by
+   `alpha/rank`.
+7. **Validate** all parameters (`validate_all_parameters`).
+
+The CLI (`compose_granite_switch.py`) additionally:
+- Downloads base + adapters from the Hub (with **selective download** —
+  `_build_allow_patterns` fetches only the needed adapter subdirs).
+- Adds control tokens and configures the chat template (`tokenizer_setup.py`).
+- Picks **substitute token ids** for token exchange (probing the tokenizer for
+  LoRA prefix substitutes — see [token-exchange.md](token-exchange.md)).
+- Copies each adapter's `io.yaml` into `io_configs/<name>/` and writes
+  `adapter_index.json` (name → token id → io schema).
+- Records the HF snapshot commit SHA per adapter for provenance.
+- Emits a build report / model card via `reporting/`.
+
+## CLI reference (key flags)
+
+From `_compose_argparser()`:
+
+| Flag | Purpose | Default |
+|---|---|---|
+| `--base-model` | Base Granite model (HF id or path) | `ibm-granite/granite-4.1-3b` |
+| `--adapters` | Adapter repo ids / paths / YAML manifests | `[]` |
+| `--output` | Output directory | `./granite-with-all-aloras` |
+| `--include-adapters` | Only include names matching fnmatch globs | all |
+| `--exclude-adapters` | Exclude names (applied after include) | none |
+| `--technology-filter` | Keep only `alora` or `lora` adapters | both |
+| `--technology` | Override the technology *label* (vs filter) | auto-detect |
+| `--built-in-adapters` | Names for empty-LoRA placeholder slots | `[]` |
+| `--lora-rank` / `--lora-alpha` | Rank/alpha for built-in slots | `8` / `=rank` |
+| `--switch-head-dim` | Override switch attention head dim | from config |
+| `--list-adapters` | List available adapters and exit (no build) | off |
+| `--debug-fields` | Include `original_path` in `adapter_index.json` | off |
+
+## Adapter discovery
+
+`adapter_discovery.py` supports three adapter sources:
+
+1. **HF repo id** — e.g. `ibm-granite/granitelib-rag-r1.0`. May be an *adapter
+   library* (multiple adapters in subdirs) or a single adapter.
+2. **Local path** — a directory with `adapter_config.json` + weights.
+3. **YAML manifest** — declares adapters pointing to arbitrary locations.
+
+`filter_adapters` applies include/exclude globs and technology filters. Selective
+download (`_build_allow_patterns` + `resolve_repo_path`) fetches only the needed
+files.
+
+## Constraints from CLAUDE.md
+
+- All end-to-end tests must build models through `GraniteSwitchComposer` — never
+  hand-assemble `GraniteSwitchConfig` or call `transfer_base_weights` directly
+  (gotcha #5). Extend the composer if it can't handle a case (e.g. zero-adapter
+  skinning is supported — `adapter_paths=None`).
+
+## Tests
+
+`tests/composer/` — e.g. `test_compose_e2e.py`, `test_adapter_discovery`-related
+files, `test_weight_remapper.py`, `test_tokenizer_setup.py`,
+`test_chat_template.py`, `test_validator.py`, `test_skinning_equivalence.py`.

--- a/openwiki/architecture/configuration.md
+++ b/openwiki/architecture/configuration.md
@@ -1,0 +1,95 @@
+# Configuration: `GraniteSwitchConfig`
+
+[← Overview](overview.md)
+
+**Source:** `src/granite_switch/config.py`.
+
+`GraniteSwitchConfig` is the single source of truth for model shape, shared by
+all three subsystems. It **extends** `transformers.GraniteMoeHybridConfig`, so
+every base-Granite parameter is available plus the switch/adapter fields below.
+
+```python
+from granite_switch import GraniteSwitchConfig   # or granite_switch.config
+```
+
+`model_type = "granite_switch"` — this is what triggers auto-registration and
+vLLM plugin dispatch.
+
+## Switch / adapter parameters
+
+| Parameter | Type | Default | Meaning |
+|---|---|---|---|
+| `num_adapters` | int | `0` | Number of *real* LoRA adapters (index 0 = base). `0` = plain skinning |
+| `adapter_token_ids` | list[int] | `None` | Control token id per adapter; `[i]` activates adapter `i+1`. Must be unique |
+| `adapter_substitute_token_ids` | list[int] | `None` | Substitute id per adapter for [token exchange](token-exchange.md). Required when `num_adapters > 0` |
+| `adapter_names` | list[str] | `None` | Ordered names for name→index mapping |
+| `adapter_ranks` | list[int] | `None` | Per-adapter LoRA rank; length must equal `num_adapters` |
+| `max_lora_rank` | int | `8` | Max rank across adapters (allocation). Must equal `max(adapter_ranks)` |
+| `lora_target_modules` | list[str] | auto | Module *groups* to apply LoRA to (see below) |
+| `control_token_gain` | float | `15.0` | Attention gain for control/non-control separation in the switch |
+| `switch_head_dim` | int | `32` | Q/K/V dim in switch attention (aligned to decoder head dim at runtime) |
+| `fused_add_norm` | bool | `False` | vLLM residual-norm convention (for bit-exact skinning equivalence) |
+
+`projection_head_dim` is computed (`head_dim` or `hidden_size //
+num_attention_heads`) and used by the switch and vLLM head-size convertor. It is
+*not* set as `head_dim` because HF's RoPE also reads that field.
+
+## `lora_target_modules` groups
+
+Auto-derived when `None` and `num_adapters > 0`:
+
+| Group | Wraps |
+|---|---|
+| `qkv_proj` | fused Q/K/V |
+| `o_proj` | attention output |
+| `shared_input_linear` | shared_mlp fused gate+up |
+| `shared_output_linear` | shared_mlp down |
+
+## Validation rules (enforced in `__init__`)
+
+- `num_adapters >= 0`.
+- If `num_adapters > 0`:
+  - `adapter_token_ids` length == `num_adapters`, all unique.
+  - `adapter_substitute_token_ids` required, length == `num_adapters`, all `>= 0`.
+  - `adapter_token_ids` required whenever substitutes are given.
+  - `adapter_ranks` required, length == `num_adapters`,
+    `max(adapter_ranks) == max_lora_rank`.
+- `layer_types` defaults to all `"attention"`, length == `num_hidden_layers`
+  (which includes the switch's index-0 slot when adapters are present, so
+  `DynamicCache` pre-allocation matches).
+
+## Example (from CLAUDE.md)
+
+```json
+{
+  "model_type": "granite_switch",
+  "architectures": ["GraniteSwitchForCausalLM"],
+  "num_adapters": 4,
+  "adapter_token_ids": [100, 101, 102, 103],
+  "adapter_substitute_token_ids": [100264, 100264, 100264, 100264],
+  "adapter_names": ["adapter_0", "adapter_1", "adapter_2", "adapter_3"],
+  "max_lora_rank": 8,
+  "adapter_ranks": [8, 8, 8, 8],
+  "switch_head_dim": 32,
+  "control_token_gain": 15.0
+}
+```
+
+> Note: the CLAUDE.md example predates the token-exchange rewrite and still
+> mentions `hiding_groups`/`hiding_policy`/`control_dims`. Those KV-hiding fields
+> were removed in commit `e7b9330`; the current config uses
+> `adapter_substitute_token_ids` + `control_token_gain` instead.
+
+## Granite-specific multipliers — never hardcode
+
+Inherited from the base config; always load from config:
+
+- `attention_multiplier` — attention score scaling (instead of `1/sqrt(head_dim)`)
+- `logits_scaling` — applied to final logits (~8.0; main diff vs Llama)
+- `residual_multiplier` — applied to residual connections
+- `embedding_multiplier` — applied to input embeddings (used in
+  `GraniteSwitchModel.forward`: `inputs_embeds * self.embedding_multiplier`)
+
+## Tests
+
+`tests/unit/test_config.py`, `tests/unit/test_config_edge_cases.py`.

--- a/openwiki/architecture/hf-backend.md
+++ b/openwiki/architecture/hf-backend.md
@@ -1,0 +1,75 @@
+# HuggingFace Backend
+
+[← Overview](overview.md)
+
+**Source:** `src/granite_switch/hf/` (requires the `hf` extra).
+**Purpose:** prototyping, optional router training, and CPU/GPU inference with
+full `transformers` integration.
+
+## Layout
+
+```
+hf/
+├── __init__.py                  # registers with AutoConfig / AutoModelForCausalLM
+├── modeling_granite_switch.py   # GraniteSwitchForCausalLM, GraniteSwitchModel
+├── core/lora.py                 # SwitchedLoRALinear, MergedSwitchedLoRALinear
+└── switch/single.py             # SingleSwitch (attention-based selection)
+```
+
+## Auto-registration
+
+Importing `granite_switch.hf` registers the model with transformers:
+
+```python
+AutoConfig.register("granite_switch", GraniteSwitchConfig)
+AutoModelForCausalLM.register(GraniteSwitchConfig, GraniteSwitchForCausalLM)
+```
+
+So `AutoModelForCausalLM.from_pretrained("./my-model")` works once the package is
+imported. Registration is wrapped in a try/except (safe if already registered).
+
+## Model classes
+
+- **`GraniteSwitchModel`** (base, extends `GraniteMoeHybridPreTrainedModel`):
+  owns `embed_tokens`, the `switch` (`SingleSwitch`), and the decoder `layers`.
+  Its `forward` (around line 232) runs the switch → embed → decoder flow from
+  [overview.md](overview.md#runtime-data-flow-inference).
+- **`GraniteSwitchForCausalLM`** adds the LM head and `GenerationMixin`.
+- **`GraniteSwitchAttentionDecoderLayer`** wraps a Granite attention block +
+  `shared_mlp`, threading `adapter_indices` into LoRA layers (and stashing them
+  on `shared_mlp` via the context-passing pattern — see [lora.md](lora.md)).
+
+`GraniteSwitchModel.forward` exposes `self._last_adapter_indices` for tests and
+debugging.
+
+## Fused projections & equivalence
+
+The HF backend deliberately uses **fused** QKV and gate-up projections to mirror
+the vLLM architecture. Consequence: it is **not bit-exact** with upstream
+`GraniteMoeHybridForCausalLM` (separate projections → different float reduction
+order). The HF skinning-equivalence tests in
+`tests/composer/test_skinning_equivalence.py` are therefore skipped; the vLLM
+equivalence tests are authoritative (CLAUDE.md gotcha #9).
+
+## Attention-backend quirks
+
+- The **eager** backend does NOT treat `attention_mask=None` as causal (it means
+  "full attention"). SDPA and FlashAttention handle `None` correctly via the
+  `is_causal` attribute (CLAUDE.md gotcha #6).
+- `tests/hf/test_single_switch.py` auto-detects which backends work on the
+  current platform (probes each with a `k=-inf` GQA call at import) and skips the
+  rest.
+
+## transformers version handling
+
+`modeling_granite_switch.py` branches on `_TRANSFORMERS_GE_5_9` for the
+`create_causal_mask` kwargs (`inputs_embeds` vs `input_embeds` +
+`cache_position`). Supported range is transformers 5.5–5.9 (see
+[configuration.md](configuration.md) / `pyproject.toml`).
+
+## Tests
+
+`tests/hf/` — `test_model_forward.py`, `test_generation.py`,
+`test_single_switch.py`, `test_single_switch_e2e.py`, `test_lora.py`,
+`test_token_exchange.py`, `test_qk_norm.py`, `test_quantization.py`,
+`test_granite4_mini.py`, `test_granite4_fullsize.py`. All run on CPU.

--- a/openwiki/architecture/lora.md
+++ b/openwiki/architecture/lora.md
@@ -1,0 +1,89 @@
+# LoRA Layers
+
+[← Overview](overview.md)
+
+**Source:** `src/granite_switch/hf/core/lora.py` (HF),
+`src/granite_switch/vllm/core/lora.py` (vLLM, Punica kernels).
+
+LoRA layers are where the selected adapter's low-rank weights are actually
+applied. Both backends implement the same math; only the kernel differs.
+
+## The two classes
+
+- **`SwitchedLoRALinear`** — wraps a single base `nn.Linear`. Stacks all
+  adapters' `lora_A` / `lora_B` in tensors and applies the right one per token.
+- **`MergedSwitchedLoRALinear`** — for **fused** projections (QKV, gate+up). The
+  base weight is one fused matrix, but each fused slice has its own LoRA. Stores
+  a `lora_A_slices` / `lora_B_slices` `ParameterList`.
+
+> The HF backend uses **fused** QKV and gate-up projections to match the vLLM
+> architecture. This means it is *not* bit-exact with upstream HuggingFace
+> `GraniteMoeHybridForCausalLM` (which uses separate projections) — the fused
+> reduction order changes floating point results. The vLLM skinning-equivalence
+> tests are the authoritative check (CLAUDE.md gotcha #9).
+
+## Per-token application (the core of `forward`)
+
+```python
+output = self.base_layer(x)          # dense base output, always computed
+if adapter_indices is None or not torch.any(adapter_indices > 0):
+    return output                    # fast path: pure base, no LoRA
+
+for adapter_idx in active_adapters:  # unique adapters present in this batch
+    token_mask   = adapter_indices_flat == adapter_idx
+    tensor_idx   = adapter_idx - 1   # 1-indexed selection → 0-indexed tensor
+    lora_a       = self.lora_A[tensor_idx, 0]   # [rank, in_features]
+    lora_b       = self.lora_B[tensor_idx, 0]   # [out_features, rank]
+    x_adapter    = x_flat[token_indices]
+    delta        = (x_adapter @ lora_a.t()) @ lora_b.t()
+    output_flat[token_indices] += delta
+```
+
+Key points:
+
+- **Base output is always dense-computed**; LoRA is an *additive delta* applied
+  only to tokens whose `adapter_indices > 0`.
+- The loop is over the *unique adapters actually present* in the batch, so a
+  batch that only touches one adapter pays for one.
+- `lora_B` is **pre-scaled by `alpha/rank`** during weight loading (in the
+  composer), not at runtime — so no scaling factor appears here. This is a
+  deliberate optimization noted in the code (`lora.py` line ~58).
+- `adapter_idx - 1` maps the 1-indexed selection convention to the 0-indexed
+  weight tensor. (Contrast with vLLM Punica, which uses `-1` for "no adapter" —
+  see [overview.md](overview.md#index-numbering-convention-important).)
+
+## Context-passing pattern
+
+Some call sites (like `shared_mlp` inside a `GraniteMoeHybrid` block) can't
+thread `adapter_indices` explicitly through their forward signature. For those,
+the decoder layer stashes indices on the module via `_adapter_indices`
+(see `GraniteSwitchAttentionDecoderLayer._set_shared_mlp_context` in
+`hf/modeling_granite_switch.py`), and `forward` falls back to that stored value
+when its argument is `None`.
+
+## Which modules get LoRA
+
+Driven by `config.lora_target_modules` (module *group* names), auto-derived in
+`GraniteSwitchConfig`:
+
+| Group | What it wraps |
+|---|---|
+| `qkv_proj` | fused Q/K/V projection |
+| `o_proj` | attention output projection |
+| `shared_input_linear` | fused gate+up of `shared_mlp` |
+| `shared_output_linear` | `shared_mlp` down projection |
+
+See [domain/supported-models.md](../domain/supported-models.md) for the full
+base-model → Switch parameter-path mapping.
+
+## vLLM variant
+
+`src/granite_switch/vllm/core/lora.py` implements the same selection but uses
+**Punica kernels** (`lora_kernel_meta.py`) for batched low-rank matmuls and
+supports tensor parallelism. See [vllm-backend.md](vllm-backend.md).
+
+## Tests
+
+- `tests/hf/test_lora.py`, `tests/vllm/test_lora.py`
+- `tests/shared/lora_cases.py` (parametrized shared cases)
+- `tests/vllm/test_tp_lora.py` (tensor-parallel LoRA)

--- a/openwiki/architecture/overview.md
+++ b/openwiki/architecture/overview.md
@@ -1,0 +1,108 @@
+# Architecture Overview
+
+[← Back to Quickstart](../quickstart.md)
+
+Granite Switch has three cooperating subsystems that share one weight format:
+
+```
+                    ┌─────────────────────────────────────┐
+                    │            composer/                 │
+   base model  +    │  discover → load → transfer weights  │  →  checkpoint
+   adapters         │  → tokenizer/chat template → validate│     (safetensors +
+                    └─────────────────────────────────────┘      config.json +
+                                     │                            adapter_index.json)
+                                     │  same checkpoint, no conversion
+                     ┌───────────────┴───────────────┐
+                     ▼                                ▼
+             ┌───────────────┐               ┌───────────────┐
+             │   hf/ backend │               │  vllm/ backend│
+             │ (prototyping, │               │  (production, │
+             │   training)   │               │ Punica kernels)│
+             └───────────────┘               └───────────────┘
+```
+
+- **[`composer/`](composer.md)** builds checkpoints (requires the `compose` extra).
+- **[`hf/`](hf-backend.md)** is a `transformers`-native model for prototyping and
+  training (requires `hf` extra).
+- **[`vllm/`](vllm-backend.md)** is a vLLM plugin for fast serving (requires `vllm`).
+
+The single source of truth for the model shape is
+[`GraniteSwitchConfig`](configuration.md) in `src/granite_switch/config.py`,
+shared by all three.
+
+---
+
+## Runtime data flow (inference)
+
+Both backends implement the same logical forward pass. In the HuggingFace
+backend (`src/granite_switch/hf/modeling_granite_switch.py`) it looks like this:
+
+```
+input_ids ──► SingleSwitch ──► (adapter_indices, modified_input_ids)
+                  │                       │
+                  │  detect control       │  control tokens rewritten
+                  │  tokens, emit          │  to substitute ids
+                  │  per-token index       ▼
+                  │                   embed_tokens(modified_input_ids)
+                  │                        │
+                  └──── adapter_indices ───┤
+                                           ▼
+                              decoder layers (attention + shared_mlp)
+                                           │
+                            SwitchedLoRALinear applies adapter i's
+                            LoRA weights to tokens where index == i
+                                           ▼
+                                       logits
+```
+
+Key files:
+- Switch: `src/granite_switch/hf/switch/single.py` → [switch.md](switch.md)
+- Token exchange logic: same file + config → [token-exchange.md](token-exchange.md)
+- LoRA application: `src/granite_switch/hf/core/lora.py` → [lora.md](lora.md)
+- Model wiring: `src/granite_switch/hf/modeling_granite_switch.py` (see
+  `GraniteSwitchModel.forward`, around line 232)
+
+---
+
+## Why this design (the "why")
+
+Standard LoRA trains each adapter against *its own* KV distribution. Switching
+adapters mid-flow (as in a multi-step RAG pipeline) forces the KV cache to be
+discarded and recomputed at each step — the dominant latency cost.
+
+Granite Switch's adapters are all trained against a **common normalized KV
+cache**, so:
+
+1. They coexist in one checkpoint without cross-contamination.
+2. The base prefill is reused across adapter switches (the aLoRA speedup —
+   see the live-race telemetry linked from the README).
+3. Adapter functions can be developed, benchmarked, and swapped independently,
+   like software libraries.
+
+The **token-exchange** mechanism (replacing a commit `e7b9330`, "Replace
+control-token KV hiding with token-exchange") is what keeps the KV cache clean:
+control tokens are rewritten to benign substitutes before the decoder embeds
+them, so the decoder never stores a foreign token's key/value.
+
+---
+
+## Index-numbering convention (important)
+
+There are two different conventions in the codebase — a frequent source of bugs:
+
+| Context | "no adapter" | adapter N |
+|---|---|---|
+| Control-token / `adapter_indices` (HF & switch) | `0` | `N` (1-indexed) |
+| vLLM Punica kernels (internal) | `-1` | `N-1` (0-indexed) |
+
+The vLLM backend converts via `adapter_indices - 1` internally. See
+[vllm-backend.md](vllm-backend.md).
+
+`SingleSwitch` cannot transition *back* to base mid-sequence — once an adapter
+activates it stays active for the rest of the sequence (documented in
+`config.py` and `switch/single.py`).
+
+---
+
+Continue to: [The Switch](switch.md) · [Token exchange](token-exchange.md) ·
+[LoRA layers](lora.md) · [Composer](composer.md)

--- a/openwiki/architecture/switch.md
+++ b/openwiki/architecture/switch.md
@@ -1,0 +1,82 @@
+# The Switch (`SingleSwitch`)
+
+[← Overview](overview.md)
+
+**Source:** `src/granite_switch/hf/switch/single.py` (HF),
+`src/granite_switch/vllm/switch/single.py` (vLLM).
+
+The switch is the component that turns a token sequence into a per-token
+**adapter selection**. It is intentionally tiny (a single attention head with a
+single active dimension) so it adds negligible cost.
+
+## What it computes
+
+Given `input_ids` and the configured `adapter_token_ids`, the switch returns:
+
+```python
+(adapter_indices, modified_input_ids)
+#  adapter_indices:    [batch, seq_len]  0 = base, 1+ = adapter N
+#  modified_input_ids: [batch, seq_len]  control tokens rewritten to substitutes
+```
+
+## How it works — attention as a cumulative "latch"
+
+The clever trick: instead of a learned module, the switch encodes adapter
+selection into hand-built Q/K/V vectors and lets a standard causal attention
+backend (SDPA, FlashAttention, eager) do the work. Only **dimension 0** of each
+`head_dim`-wide vector carries signal; the rest is zero padding to satisfy the
+backend's shape constraints.
+
+| Token type | key[0] | query[0] | value[0] |
+|---|---|---|---|
+| Control token for adapter N | `+gain` | `1` | `N` (adapter_id) |
+| Any other token | `-gain` | `1` | `0` |
+
+Because `Q·K = 1 × (±gain) = ±gain` regardless of `head_dim`, causal softmax
+attention makes each position attend overwhelmingly to the **most recent control
+token at or before it**. The attended `value[0]` is that control token's
+adapter id — so the output is effectively "which adapter is active at this
+position", latched forward until the next control token.
+
+`control_token_gain` (default `15.0`, in `GraniteSwitchConfig`) controls how
+sharp this selection is. Higher gain → crisper one-hot attention. The
+`switch_head_dim` / `projection_head_dim` matches the decoder's native head dim
+so the switch shares the same KV cache layout.
+
+> The gain value is validated for numerical sharpness — see
+> `tests/unit/test_sharpness_equivalence.py` and
+> `tests/shared/single_switch_cases.py`.
+
+## Why "no return to base"
+
+The latch only flips *up* when it sees a control token; there is no token that
+resets to base. This is a deliberate simplification documented in both
+`config.py` and the switch docstring:
+
+> "SingleSwitch has no mechanism to transition back to base mid-sequence."
+
+For the composed-model use case (activate an adapter, generate its structured
+output) this is exactly what's wanted.
+
+## KV caching
+
+The switch participates in the model's `Cache` object like a real layer. It is
+assigned `layer_idx` (0 in HF, with decoder layers following) so its keys/values
+are stored and reused during incremental decoding. In vLLM the switch is a real
+`Attention` module discovered separately for KV allocation — which is why
+`register()` in `vllm/__init__.py` subtracts 1 from the layer count for pipeline
+parallelism slicing (`_GraniteSwitchArchConfigConvertor.get_num_hidden_layers`).
+
+## Token exchange half
+
+Besides selection, the switch rewrites control tokens to substitutes using a
+lookup table (`control_to_substitute_lut`) built at construction from
+`adapter_token_ids` → `adapter_substitute_token_ids`. This is covered in detail
+in [token-exchange.md](token-exchange.md).
+
+## Tests
+
+- `tests/hf/test_single_switch.py` — stress tests across attention backends
+  (auto-detects which backends work on the platform; see CLAUDE.md gotcha #6).
+- `tests/vllm/test_single_switch.py` — vLLM equivalence.
+- `tests/shared/single_switch_cases.py` — parametrized shared cases.

--- a/openwiki/architecture/token-exchange.md
+++ b/openwiki/architecture/token-exchange.md
@@ -1,0 +1,96 @@
+# Token Exchange
+
+[← Overview](overview.md) · [The Switch](switch.md)
+
+Token exchange is the mechanism that keeps the shared KV cache clean when
+control tokens fire adapters. It **replaced** an earlier "control-token KV
+hiding" approach (commit `e7b9330`, PR #34) with something simpler and more
+robust.
+
+## The problem
+
+Each adapter function is activated by inserting a special **control token**
+(e.g. `<guardian>`) into the input. But that token is *not* part of the base
+model's normal vocabulary distribution — if the decoder embeds it and stores its
+key/value in the KV cache, it pollutes the shared cache and can leak across
+requests or interfere with other adapters. Adapters are trained against a
+*normalized* KV cache that never contains these control tokens.
+
+## The solution
+
+The switch does two things in one pass (`SingleSwitch.forward`):
+
+1. **Selection** — detect control tokens, emit `adapter_indices`
+   (which adapter is active per token). See [switch.md](switch.md).
+2. **Rewrite** — replace each control token id with a benign **substitute id**
+   *before the decoder embeds the sequence*.
+
+```
+input_ids:          [ ..., <guardian>=100265, "text", ... ]
+                                 │  switch rewrites via LUT
+modified_input_ids: [ ..., <|start_of_role|>=100264, "text", ... ]
+                                 │
+                    embed_tokens(modified_input_ids)  ← decoder is oblivious
+```
+
+The decoder embeds `modified_input_ids` and stores *substitute* keys/values in
+the cache — indistinguishable from a no-adapter render. Meanwhile
+`adapter_indices` (computed from the *original* ids) still tells the LoRA layers
+which adapter to apply. Selection and cache state are decoupled.
+
+## The lookup table
+
+Built once at switch construction from config
+(`src/granite_switch/hf/switch/single.py`):
+
+```python
+lut = torch.full((vocab_size,), -1)          # -1 = not a control token
+for ctrl_id, sub_id in zip(adapter_token_ids,
+                           adapter_substitute_token_ids):
+    lut[ctrl_id] = sub_id
+self.register_buffer("control_to_substitute_lut", lut)
+```
+
+There is **no decoder-side LUT**, no per-forward scatter, no clone guard — the
+switch hands the decoder finished `input_ids`. This simplicity is the whole
+point of the token-exchange rewrite.
+
+## Choosing the substitute id
+
+The substitute must be a token that would *naturally* occupy that position in a
+no-adapter render, so the post-swap sequence looks normal to the model.
+
+- **ALoRA adapters**: the control token sits mid-sequence (before the invocation
+  sequence), so its substitute is chosen accordingly.
+- **LoRA adapters**: the control token is prepended at sequence position 0. The
+  composer *probes the tokenizer* to find what token normally appears at
+  position 0 of a rendered chat — for Granite 4.x this is `<|start_of_role|>`
+  (id `100264`). See `_probe_lora_substitute_token_id` in
+  `composer/compose_granite_switch.py` (well-documented there).
+
+This probe avoids hard-coding any Granite-specific token string; it reads the
+constant out of the tokenizer's own chat template at compose time.
+`tests/composer/test_lora_substitute_probe.py` pins this Granite 4.x behavior.
+
+## Config contract
+
+`GraniteSwitchConfig` enforces (see `config.py`):
+
+- `adapter_substitute_token_ids` is **required** when `num_adapters > 0`.
+- Its length must equal `num_adapters`.
+- All ids must be `>= 0` (real token ids).
+- `adapter_token_ids` must be present and unique (duplicates would collapse LUT
+  slots).
+
+## Known limitation
+
+When position 0 is a control token in a hiding group (a LoRA prefix token with
+`add_bos_token=False`), the hidden count is off by 1, causing a 1-position RoPE
+offset. This is acceptable — adapter detection stays exact and RoPE is robust to
+small positional shifts (CLAUDE.md gotcha #7).
+
+## Tests
+
+- `tests/unit/test_token_exchange.py`
+- `tests/hf/test_token_exchange.py`
+- `tests/vllm/test_token_exchange.py`

--- a/openwiki/architecture/vllm-backend.md
+++ b/openwiki/architecture/vllm-backend.md
@@ -1,0 +1,89 @@
+# vLLM Backend
+
+[← Overview](overview.md)
+
+**Source:** `src/granite_switch/vllm/` (requires the `vllm` or `vllm20` extra).
+**Purpose:** production inference — Punica LoRA kernels, PagedAttention,
+continuous batching, tensor/pipeline parallelism.
+
+## Layout
+
+```
+vllm/
+├── __init__.py             # register() — vLLM plugin entry point
+├── granite_switch_model.py # GraniteSwitchForCausalLM / GraniteSwitchModel (vLLM)
+├── core/
+│   ├── lora.py             # SwitchedLoRALinear (Punica kernels)
+│   ├── lora_kernel_meta.py # kernel metadata / batching
+│   └── decoder.py          # decoder layers
+└── switch/single.py        # SingleSwitch (vLLM Attention)
+```
+
+## Plugin registration
+
+Declared in `pyproject.toml`:
+
+```toml
+[project.entry-points."vllm.general_plugins"]
+register_granite_switch = "granite_switch.vllm:register"
+```
+
+vLLM calls `register()` on startup. It is **re-entrant** and:
+
+1. Registers `GraniteSwitchConfig` with transformers `AutoConfig`.
+2. Registers a custom `_GraniteSwitchArchConfigConvertor` so vLLM sees:
+   - `get_num_hidden_layers()` → **layer count minus 1** when adapters are
+     present (the `SingleSwitch` occupies a KV-cache placeholder slot that vLLM
+     discovers separately; PP slicing must count only physical decoder layers).
+   - `get_head_size()` → `projection_head_dim` (token exchange does not expand
+     the head dim, so it's just the base model's head dim).
+3. Registers `GraniteSwitchForCausalLM` with `ModelRegistry` (only if not
+   already present).
+
+Verify registration:
+
+```bash
+python -c "from vllm.plugins import load_general_plugins; \
+           from vllm import ModelRegistry; load_general_plugins(); \
+           print('GraniteSwitchForCausalLM' in ModelRegistry.get_supported_archs())"
+```
+
+## Index convention (Punica)
+
+vLLM's Punica kernels use `-1` for "no adapter" and 0-indexed adapters
+internally. The backend converts the switch's 1-indexed `adapter_indices` via
+`adapter_indices - 1`. See
+[overview.md](overview.md#index-numbering-convention-important).
+
+## Known limitations (from CLAUDE.md)
+
+- **TP row-parallel bias doubling** (gotcha #8): `SwitchedLoRALinear`'s
+  row-parallel bypass passes bias to all TP ranks; after all-reduce this doubles
+  the bias. *Not triggered* by any Granite arch — Granite 4.0/4.1 use
+  `attention_bias=False` and `mlp_bias=False`.
+- Single-GPU inference is the primary path; multi-GPU (TP/PP) is tested but the
+  supported-models doc notes models must fit constraints.
+
+## vLLM version story
+
+Two conflicting extras (see `pyproject.toml` `[tool.uv].conflicts`):
+
+- `[vllm]` → vLLM 0.19.1 (**default**) — works with CUDA 12.x.
+- `[vllm20]` → vLLM 0.20+ — requires CUDA 13.0+ (via PyTorch 2.11).
+
+Pick based on your CUDA driver. Details in
+[workflows/development.md](../workflows/development.md).
+
+## Weight compatibility
+
+A checkpoint saved by the HF backend (`model.save_pretrained(...)`) loads
+directly into vLLM (`LLM(model="./checkpoint")`) — no conversion. Cross-backend
+weight equivalence is guarded by `tests/integration/test_hf_to_vllm_weights.py`.
+
+## Tests
+
+`tests/vllm/` (all require a GPU): `test_model_forward.py`,
+`test_generation_equivalence.py`, `test_single_switch.py`, `test_lora.py`,
+`test_tp_lora.py`, `test_tp_integration.py`,
+`test_pipeline_parallelism_generation.py`, `test_upstream_equivalence.py`,
+`test_token_exchange.py`, `test_granite4_mini.py`, `test_granite4_fullsize.py`.

--- a/openwiki/domain/concepts.md
+++ b/openwiki/domain/concepts.md
@@ -1,0 +1,90 @@
+# Concepts & Glossary
+
+[← Quickstart](../quickstart.md)
+
+## Adapter function
+
+A **LoRA adapter trained to a specific input/output contract** — a score, a
+decision, a rewritten query — with the output schema enforced at the token level
+(by [Mellea](https://mellea.ai)). The "function" framing matters: each has a
+known signature (typed inputs/outputs), not just free-form text. This is what
+makes them *composable as software*. Contracts ship as `io.yaml` files, embedded
+into the checkpoint under `io_configs/<name>/`.
+
+## LoRA vs Activated LoRA (aLoRA)
+
+| | Standard LoRA | Activated LoRA (aLoRA) |
+|---|---|---|
+| KV distribution | trained against its **own** KV cache | trained against a **common normalized** KV cache |
+| Switching adapters mid-flow | must discard + recompute KV cache | reuses shared base prefill |
+| Multiple in one checkpoint | interfere / need joint training | coexist, activate on demand |
+| Latency in multi-step flows | high (recompute) | low (prefill reuse) |
+
+aLoRA is IBM's technology that makes many adapters share one KV cache and
+activate on demand — the reason Granite Switch can serve many capabilities from
+one deployment with no memory/latency overhead. The live-race telemetry in the
+README quantifies this (74% vs 29% KV hit rate on a multi-step RAG pipeline).
+
+## Control token
+
+A dedicated special token per adapter (e.g. `<guardian>`, `<query_rewrite>`).
+**Placing it in the input activates that adapter** from its position forward. The
+switch detects it and emits per-token `adapter_indices`. All control tokens are
+freely generatable — there is no runtime suppression (CLAUDE.md gotcha #2).
+
+## Substitute token / token exchange
+
+Because a control token isn't part of the base model's normal distribution,
+storing its key/value would pollute the shared KV cache. The switch **rewrites**
+each control token to a benign *substitute* id before the decoder embeds it, so
+the cache stays clean while `adapter_indices` (from the original ids) still
+drives LoRA selection. Full detail:
+[architecture/token-exchange.md](../architecture/token-exchange.md).
+
+## Adapter index convention
+
+- `0` = base / no adapter; `1+` = adapter N (control-token & switch convention).
+- vLLM Punica kernels internally use `-1` = no adapter, 0-indexed adapters.
+- The switch cannot return to base mid-sequence — once up, an adapter stays
+  active for the rest of the sequence.
+
+## The Switch (`SingleSwitch`)
+
+A single-head attention module with one active dimension that latches the most
+recent control token's adapter id forward via causal attention. Tiny and
+learning-free. See [architecture/switch.md](../architecture/switch.md).
+
+## Skinning
+
+Producing a Granite Switch checkpoint from a base model with **zero adapters**
+(or just structure) — the base model re-expressed in the Switch architecture
+(fused projections, switch layer machinery). Used to verify the architecture
+itself is equivalent to the base model. See the skinning-equivalence tests
+(`tests/composer/test_skinning_equivalence.py`,
+`tests/composer/test_arch_skinning.py`).
+
+## Adapter library
+
+A Hugging Face repo containing multiple adapters (e.g.
+`ibm-granite/granitelib-rag-r1.0`), each in a subdirectory with its own
+`adapter_config.json` + `io.yaml`. The composer discovers, filters, and
+selectively downloads them.
+
+## Composition
+
+Combining a base model + adapter functions into one checkpoint — analogous to
+statically linking object code. Adapters can be developed and benchmarked
+independently, then composed and swapped/upgraded without retraining.
+
+## Fused projections
+
+The HF and vLLM backends both fuse Q/K/V into `qkv_proj` and gate+up into
+`shared_input_linear`. This changes float reduction order vs upstream HF's
+separate projections — so HF is not bit-exact with upstream; vLLM equivalence is
+authoritative (CLAUDE.md gotcha #9).
+
+## The Granite multipliers
+
+Granite differs from Llama via `attention_multiplier`, `logits_scaling` (~8.0),
+`residual_multiplier`, and `embedding_multiplier`. Always read from config, never
+hardcode. See [architecture/configuration.md](../architecture/configuration.md).

--- a/openwiki/domain/supported-models.md
+++ b/openwiki/domain/supported-models.md
@@ -1,0 +1,72 @@
+# Supported Models
+
+[← Quickstart](../quickstart.md)
+
+Source of truth: [`docs/SUPPORTED_MODELS.md`](../../docs/SUPPORTED_MODELS.md).
+Architecture is detected automatically from the base model's HF
+`config.model_type` field (`composer/arch.py` → `resolve_arch`).
+
+## Feature support
+
+| Family | `model_type` | Support | KV cache handling |
+|---|---|---|:---:|
+| Granite 4.x Dense | `granite` | **Full** — primary target | Token exchange |
+
+The composer resolves architecture via descriptors in `composer/arch.py`:
+
+- `granite_dense_arch` → `model_type: granite`
+- `granite_moe_hybrid_arch` → `model_type: granitemoehybrid`
+
+Any Granite model whose config reports `model_type: granite` can serve as a base.
+
+## Example base models
+
+| Model tag | Size | Variant |
+|---|---|---|
+| `ibm-granite/granite-4.1-3b` | 3B | Dense, instruct (**default base**) |
+| `ibm-granite/granite-4.1-8b` | 8B | Dense, instruct |
+| `ibm-granite/granite-4.0-micro` | 3B | Dense, instruct |
+
+Base (non-instruct) variants like `granite-4.1-3b-base` are also supported.
+
+> Currently **single-GPU inference** is the primary supported path. Models that
+> don't fit in one GPU's memory are not yet supported.
+
+## Pre-composed checkpoints
+
+| Checkpoint | Size |
+|---|---|
+| `ibm-granite/granite-switch-4.1-3b-preview` | 3B |
+| `ibm-granite/granite-switch-4.1-8b-preview` | 8B |
+| `ibm-granite/granite-switch-4.1-30b-preview` | 30B |
+
+## Target layers (base → Switch parameter paths)
+
+### Attention
+
+| Base PEFT modules | Switch group | Parameter path |
+|---|---|---|
+| `q_proj`/`k_proj`/`v_proj` (fused) | `qkv_proj` | `model.layers.{i}.self_attn.qkv_proj.lora_{A,B}_slices.{0,1,2}` |
+| `o_proj` | `o_proj` | `model.layers.{i}.self_attn.o_proj.lora_{A,B}` |
+
+### MLP (remapped to `shared_mlp` namespace)
+
+| Base PEFT modules | Switch group | Parameter path |
+|---|---|---|
+| `gate_proj`+`up_proj` (fused) | `shared_input_linear` | `model.layers.{i}.shared_mlp.input_linear.lora_{A,B}_slices.{0,1}` |
+| `down_proj` | `shared_output_linear` | `model.layers.{i}.shared_mlp.output_linear.lora_{A,B}` |
+
+The remapping from upstream PEFT names to these paths is done by
+`AdapterRemapper` (`composer/weight_remapper.py`).
+
+## Adapter libraries to compose
+
+Published under
+[ibm-granite/granite-libraries](https://huggingface.co/collections/ibm-granite/granite-libraries):
+
+- `ibm-granite/granitelib-core-r1.0` — core capabilities
+- `ibm-granite/granitelib-rag-r1.0` — RAG (answerability, citations, query rewrite, …)
+- `ibm-granite/granitelib-guardian-r1.0` — safety / guardian checks
+
+Browse all with benchmarks in the
+[adapter function catalog](https://generative-computing.github.io/granite-switch/adapter_catalog.html).

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -1,0 +1,145 @@
+# Granite Switch — OpenWiki
+
+> Build AI models like you build software: pick adapter functions, compose them
+> into one checkpoint, deploy with one command.
+
+Granite Switch is a model architecture + toolchain for embedding **multiple LoRA
+adapters** (called *adapter functions*) into a single Granite base model. The
+result is one deployable checkpoint that serves many capabilities — RAG, safety,
+factuality, query rewriting — with no per-adapter memory or latency overhead,
+thanks to IBM's **Activated LoRA (aLoRA)** technology and a shared KV cache.
+
+This wiki explains **what** the system does, **why** it is built the way it is,
+and **where** to look in the code.
+
+---
+
+## What this repository is
+
+`granite-switch` is a single Python package (`granite_switch`) with optional
+extras for different backends. It does three things:
+
+1. **Compose** — Combine a base Granite model + several LoRA/aLoRA adapters into
+   one checkpoint that has control tokens, a chat template, and stacked adapter
+   weights. → [`composer/`](architecture/composer.md)
+2. **Run (HuggingFace)** — A `transformers`-native model class for prototyping,
+   training, and CPU/GPU inference. → [`hf/`](architecture/hf-backend.md)
+3. **Run (vLLM)** — A production inference backend using Punica LoRA kernels and
+   PagedAttention, registered as a vLLM plugin. → [`vllm/`](architecture/vllm-backend.md)
+
+Both backends read the **same checkpoint** with no conversion step.
+
+---
+
+## The core idea in 60 seconds
+
+- Each adapter function has a dedicated **control token** (e.g. `<guardian>`).
+  Placing that token in the input sequence activates the adapter from that
+  position forward.
+- A tiny attention-based **switch** (see [`SingleSwitch`](architecture/switch.md))
+  reads `input_ids`, detects control tokens, and emits a per-token
+  `adapter_indices` tensor (`0` = base, `1+` = adapter N).
+- The switch also performs **token exchange**: it rewrites each control token id
+  to a benign *substitute* id before the decoder embeds the sequence, so the
+  decoder never sees a foreign token and the KV cache stays clean.
+- LoRA layers ([`SwitchedLoRALinear`](architecture/lora.md)) apply the right
+  adapter's weights per token based on `adapter_indices`.
+- Because all adapters are trained against the **same normalized KV cache**, the
+  base prefill is reused across adapter switches instead of recomputed — the key
+  aLoRA speedup.
+
+Read the full mechanism in [architecture/token-exchange.md](architecture/token-exchange.md).
+
+---
+
+## Install
+
+Uses [uv](https://docs.astral.sh/uv/) for local dev; `pip` for end users.
+
+```bash
+# End users
+pip install "granite-switch[vllm]"      # production inference
+pip install "granite-switch[hf]"        # HuggingFace prototyping
+pip install "granite-switch[compose]"   # build/compose checkpoints
+pip install "granite-switch[dev]"       # everything
+
+# Local development (this repo)
+uv sync --extra dev
+```
+
+Requires Python 3.11–3.13, PyTorch 2.10+, transformers 5.5–5.9.
+See [workflows/development.md](workflows/development.md) for the vLLM 0.19 vs 0.20
+version story (CUDA compatibility).
+
+---
+
+## Three common tasks
+
+### 1. Compose a checkpoint
+
+```bash
+python -m granite_switch.composer.compose_granite_switch \
+  --base-model ibm-granite/granite-4.1-3b \
+  --adapters ibm-granite/granitelib-core-r1.0 \
+             ibm-granite/granitelib-rag-r1.0 \
+             ibm-granite/granitelib-guardian-r1.0 \
+  --output ./my-model
+```
+
+Full CLI + pipeline: [workflows/compose-a-model.md](workflows/compose-a-model.md).
+
+### 2. Serve with vLLM + Mellea (recommended)
+
+```bash
+python -m vllm.entrypoints.openai.api_server \
+  --model ibm-granite/granite-switch-4.1-3b-preview --port 8000
+```
+
+Then call typed adapter functions through [Mellea](https://mellea.ai). See
+[workflows/inference.md](workflows/inference.md).
+
+### 3. Prototype with HuggingFace
+
+```python
+from granite_switch.hf import GraniteSwitchForCausalLM
+model = GraniteSwitchForCausalLM.from_pretrained("./my-model")
+```
+
+---
+
+## Documentation map
+
+### Architecture
+- [Overview & data flow](architecture/overview.md) — how the pieces connect
+- [The Switch (`SingleSwitch`)](architecture/switch.md) — attention-based adapter selection
+- [Token exchange](architecture/token-exchange.md) — the KV-cache-safe control mechanism
+- [LoRA layers](architecture/lora.md) — `SwitchedLoRALinear` and per-token weight application
+- [Composer](architecture/composer.md) — how checkpoints are built
+- [HuggingFace backend](architecture/hf-backend.md)
+- [vLLM backend](architecture/vllm-backend.md)
+- [Configuration](architecture/configuration.md) — `GraniteSwitchConfig` reference
+
+### Workflows
+- [Compose a model](workflows/compose-a-model.md)
+- [Run inference](workflows/inference.md)
+- [Development & testing](workflows/development.md)
+
+### Domain
+- [Concepts & glossary](domain/concepts.md) — adapter functions, aLoRA vs LoRA, control tokens
+- [Supported models](domain/supported-models.md)
+
+---
+
+## Ecosystem context
+
+Granite Switch is one layer of a coordinated stack:
+
+| Component | Role |
+|---|---|
+| [Granite models](https://huggingface.co/ibm-granite) | Base models (3B/8B/30B) |
+| [Granite Libraries](https://huggingface.co/collections/ibm-granite/granite-libraries) | Pre-trained adapter functions to compose |
+| **Granite Switch** (this repo) | Architecture + composer that embeds adapters |
+| [Mellea](https://mellea.ai) | Orchestrates adapter functions as typed calls with constrained decoding |
+
+Sources: [`README.md`](../README.md), [`pyproject.toml`](../pyproject.toml),
+[`CLAUDE.md`](../CLAUDE.md).

--- a/openwiki/workflows/compose-a-model.md
+++ b/openwiki/workflows/compose-a-model.md
@@ -1,0 +1,103 @@
+# Workflow: Compose a Model
+
+[← Quickstart](../quickstart.md) · Architecture: [Composer](../architecture/composer.md)
+
+Composing produces a single checkpoint (base + embedded adapters + control tokens
++ chat template) that runs on both backends.
+
+## Prerequisites
+
+```bash
+pip install "granite-switch[compose]"    # or: uv sync --extra compose
+```
+
+Optionally speed up downloads:
+
+```bash
+pip install "huggingface_hub[hf_transfer]"
+huggingface-cli login
+export HF_HUB_ENABLE_HF_TRANSFER=1
+```
+
+## Basic compose
+
+```bash
+python -m granite_switch.composer.compose_granite_switch \
+  --base-model ibm-granite/granite-4.1-3b \
+  --adapters ibm-granite/granitelib-core-r1.0 \
+             ibm-granite/granitelib-rag-r1.0 \
+             ibm-granite/granitelib-guardian-r1.0 \
+  --output ./my-model
+```
+
+Use the [adapter function catalog / composer UI](https://generative-computing.github.io/granite-switch/adapter_catalog.html)
+to browse adapters and generate a ready-to-run command.
+
+## Common variations
+
+```bash
+# List what a library contains, don't build
+--adapters ibm-granite/granitelib-rag-r1.0 --list-adapters
+
+# Include only specific adapters (fnmatch globs)
+--adapters ibm-granite/granitelib-rag-r1.0 --include-adapters answerability 'query_*'
+
+# Exclude one adapter
+--adapters ibm-granite/granitelib-guardian-r1.0 --exclude-adapters factuality-detection
+
+# Only aLoRA adapters
+--adapters ibm-granite/granitelib-rag-r1.0 --technology-filter alora
+
+# Built-in empty-LoRA slots (placeholders you can train later)
+--built-in-adapters base --lora-rank 8
+```
+
+Full flag table: [architecture/composer.md](../architecture/composer.md#cli-reference-key-flags).
+
+## What lands in the output directory
+
+- `config.json` — `GraniteSwitchConfig` (num_adapters, token ids, ranks, …)
+- `model.safetensors*` — base weights (fused) + stacked adapter LoRA weights
+- `tokenizer*` — with added control tokens and an adapter-aware chat template
+- `adapter_index.json` — name → control token id → io schema mapping
+- `io_configs/<adapter>/io.yaml` — per-adapter input/output contracts
+- build report / model card (from `composer/reporting/`)
+
+## Programmatic API
+
+```python
+from granite_switch.composer import GraniteSwitchComposer
+
+model = GraniteSwitchComposer.from_base_and_adapters(
+    base_model_name_or_path="ibm-granite/granite-4.1-3b",
+    adapter_paths=["/path/to/adapter_a", "/path/to/adapter_b"],
+    adapter_token_ids=[100265, 100266],
+    adapter_substitute_token_ids=[100264, 100264],
+    adapter_names=["adapter_a", "adapter_b"],
+)
+model.save_pretrained("./my-model")
+```
+
+The pipeline steps are documented in
+[architecture/composer.md](../architecture/composer.md#the-compose-pipeline).
+
+## Skip composition
+
+Use a pre-composed checkpoint from Hugging Face:
+
+- `ibm-granite/granite-switch-4.1-3b-preview`
+- `ibm-granite/granite-switch-4.1-8b-preview`
+- `ibm-granite/granite-switch-4.1-30b-preview`
+
+## Bring your own adapter
+
+See the tutorial guide
+[`tutorials/guides/build_your_own_adapter.md`](../../tutorials/guides/build_your_own_adapter.md)
+— train a LoRA/aLoRA against a Granite base, then compose it like any other.
+
+## Validation
+
+Every compose run finishes with `validate_all_parameters` (in
+`composer/validator.py`). End-to-end tests always build through the composer
+(never hand-assemble config) — see CLAUDE.md gotcha #5 and
+`tests/composer/test_compose_e2e.py`.

--- a/openwiki/workflows/development.md
+++ b/openwiki/workflows/development.md
@@ -1,0 +1,123 @@
+# Workflow: Development & Testing
+
+[← Quickstart](../quickstart.md)
+
+## Setup
+
+This project uses [uv](https://docs.astral.sh/uv/).
+
+```bash
+uv sync                    # core only (config)
+uv sync --extra hf         # HuggingFace backend
+uv sync --extra vllm       # vLLM backend (0.19.1 default)
+uv sync --extra compose    # composer tools
+uv sync --extra dev        # everything
+```
+
+Requires Python 3.11–3.13, PyTorch 2.10+, transformers 5.5–5.9.
+
+### vLLM version conflict (important)
+
+`pyproject.toml` defines two mutually exclusive vLLM tracks
+(`[tool.uv].conflicts`):
+
+| Extra / group | vLLM | Requires |
+|---|---|---|
+| `vllm` / `vllm19` (default) | 0.19.1 | CUDA 12.x-compatible |
+| `vllm20` / `dev-vllm20` | 0.20+ | CUDA 13.0+ (PyTorch 2.11) |
+
+Default is vLLM 0.19.1 because 0.20 pulls CUDA 13 which breaks many CUDA 12.x
+environments. Use the `vllm20` variants only if your driver supports CUDA 13+.
+
+## Package import paths
+
+```python
+from granite_switch import GraniteSwitchConfig
+from granite_switch.hf import GraniteSwitchForCausalLM, SingleSwitch
+from granite_switch.hf.core.lora import SwitchedLoRALinear
+from granite_switch.vllm import register
+from granite_switch.composer import GraniteSwitchComposer
+```
+
+## Running tests
+
+Always use `-v -s --tb=short` (and `-x` to fail fast). Check the GPU first —
+hardware can change between sessions:
+
+```bash
+python -c "import torch; print('GPU' if torch.cuda.is_available() else 'CPU only')"
+```
+
+Run **incrementally by directory**, fastest first — never the whole suite as one
+command:
+
+```bash
+# 1. Unit (fastest, CPU)
+pytest tests/unit/ -v -s --tb=short -x
+
+# 2. HF (CPU), by file
+pytest tests/hf/test_single_switch.py -v -s --tb=short -x
+pytest tests/hf/test_model_forward.py -v -s --tb=short -x
+
+# 3. vLLM (GPU required), by file
+pytest tests/vllm/test_single_switch.py -v -s --tb=short -x
+pytest tests/vllm/test_model_forward.py -v -s --tb=short -x
+
+# 4. Composer (CPU)
+pytest tests/composer/ -v -s --tb=short -x
+
+# 5. Integration (slowest, GPU)
+pytest tests/integration/ -v -s --tb=short -x
+
+# Debug a pattern
+pytest tests/ -k "token_exchange" -v -s --tb=short -x
+```
+
+### pytest markers (`pyproject.toml`)
+
+| Marker | Meaning |
+|---|---|
+| `gpu` | requires CUDA GPU |
+| `vllm` | requires vLLM installed |
+| `slow` | > 30s |
+| `deep` | expensive code-theory tests (m=8 / 256-dim); run with `pytest -m deep` |
+| `requires_model` | needs a real model checkpoint |
+
+Default `addopts` ignore `tests/_legacy` and exclude `deep` (`-m "not deep"`).
+
+### Test directory map
+
+| Dir | Scope | Hardware |
+|---|---|---|
+| `tests/unit/` | config, token exchange, sharpness | CPU |
+| `tests/hf/` | HF backend forward/generation/lora | CPU |
+| `tests/vllm/` | vLLM forward, TP/PP, kernels, equivalence | GPU |
+| `tests/composer/` | discovery, weight transfer, chat template, skinning | CPU |
+| `tests/integration/` | cross-backend weights, e2e compose | GPU |
+| `tests/shared/` | parametrized cases + utilities (imported, not run alone) | — |
+
+Files prefixed `_` (e.g. `_lora_tests.py`, `_tp_integration_worker.py`) are
+subprocess workers / shared test bodies, invoked by the matching `test_*.py`.
+
+## Where to put throwaway scripts
+
+Use `scratch/` (gitignored) for debug/diagnostic scripts — **never** `tests/`.
+`pytest tests/` must only run curated, maintained tests (CLAUDE.md).
+
+## File organization rules
+
+- All `.md` docs go under `docs/` (exceptions: root `README.md`, `CLAUDE.md`, and
+  this `openwiki/`).
+- All `test_*.py` go under `tests/` in the right subdir.
+- Scripts: `snake_case.py`; docs: `UPPER_CASE.md`.
+
+## Git workflow
+
+See [`docs/GIT_WORKFLOW.md`](../../docs/GIT_WORKFLOW.md). Quick reference:
+
+- Branch: `feature/ticket-ID-description` or `bugfix/ticket-ID-description`.
+- Flow: branch from `main` → develop → rebase → PR → merge → delete branch.
+- Verify comments match code before committing.
+- **Never sign commits as Claude** (project instruction).
+
+License: Apache-2.0 (SPDX headers on every source file).

--- a/openwiki/workflows/inference.md
+++ b/openwiki/workflows/inference.md
@@ -1,0 +1,96 @@
+# Workflow: Run Inference
+
+[← Quickstart](../quickstart.md)
+
+There are three ways to invoke adapter functions. **Mellea + vLLM is the
+recommended path** — it handles control tokens, prompt rewriting, and constrained
+decoding so you work with typed function calls, not raw tokens.
+
+## Option 1 — vLLM + Mellea (recommended, production)
+
+Start the server:
+
+```bash
+pip install "granite-switch[vllm]" mellea
+python -m vllm.entrypoints.openai.api_server \
+  --model ibm-granite/granite-switch-4.1-3b-preview --port 8000
+```
+
+Call an adapter function:
+
+```python
+from mellea.backends.openai import OpenAIBackend
+from mellea.stdlib.components.chat import Message
+from mellea.stdlib.components.intrinsic.guardian import guardian_check
+from mellea.stdlib.context import ChatContext
+
+backend = OpenAIBackend(
+    model_id="ibm-granite/granite-switch-4.1-3b-preview",
+    base_url="http://localhost:8000/v1",
+    api_key="unused",
+)
+backend.register_embedded_adapter_model("ibm-granite/granite-switch-4.1-3b-preview")
+
+ctx = ChatContext().add(Message("user", "Group X people are all lazy."))
+score = guardian_check(ctx, backend, "social_bias", scoring_schema="user_prompt")
+print(f"social_bias score: {score:.3f}")   # => 0.964
+```
+
+Mellea maps the requested capability (`social_bias`) to its control token,
+places it correctly (ALoRA vs LoRA placement), and enforces the output schema at
+the token level. See the guide
+[`tutorials/guides/mellea_with_granite_switch.md`](../../tutorials/guides/mellea_with_granite_switch.md).
+
+## Option 2 — HuggingFace (prototyping)
+
+```python
+from granite_switch.hf import GraniteSwitchForCausalLM
+from transformers import AutoTokenizer
+
+model = GraniteSwitchForCausalLM.from_pretrained("./my-model")
+tok = AutoTokenizer.from_pretrained("./my-model")
+
+# The chat template accepts adapter_name= to place the control token for you.
+prompt = tok.apply_chat_template(
+    [{"role": "user", "content": "..."}],
+    adapter_name="answerability",
+    add_generation_prompt=True,
+    tokenize=False,
+)
+```
+
+The chat template (built by `composer/tokenizer_setup.py`) inserts the right
+control token given `adapter_name=`. Inspect `model._last_adapter_indices` after
+a forward to see the per-token selection.
+
+## Option 3 — raw control tokens
+
+You can place a control token directly in the input; the switch will detect it.
+This is the lowest-level path and usually only used in tests. Token ids live in
+`config.adapter_token_ids` and the name mapping in `adapter_index.json`.
+
+## Control-token placement rules
+
+From the chat template logic (`tokenizer_setup.configure_chat_template`):
+
+- **ALoRA adapters**: control token placed immediately before the adapter's
+  `alora_invocation_tokens` (matched inside the user message) or right before the
+  generation prompt.
+- **LoRA adapters**: control token placed at sequence position 0 (prefix).
+
+Both cases are made KV-safe by [token exchange](../architecture/token-exchange.md).
+
+## Pre-download for faster startup
+
+```bash
+HF_HUB_ENABLE_HF_TRANSFER=1 hf download ibm-granite/granite-switch-4.1-3b-preview
+```
+
+## Tutorials to try
+
+- [Hello Mellea](../../tutorials/notebooks/hello_mellea.ipynb) — 5 min
+- [RAG Flow](../../tutorials/notebooks/rag_flow.ipynb) — rewrite + answerability + citations + guardians
+- [aLoRA vs LoRA race](../../tutorials/notebooks/alora_vs_lora_race.ipynb) — throughput comparison
+
+See [`tutorials/README.md`](../../tutorials/README.md) for the full list and
+guided learning paths.


### PR DESCRIPTION
## Summary

Adds a structured documentation set under `openwiki/` that explains the Granite Switch architecture, workflows, and domain concepts — written for both human contributors and coding agents.

OpenWiki Agent based on Pi.dev harness https://github.com/barvhaim/pi-openwiki 

## What's included

**Entry point**
- `openwiki/quickstart.md` — what the project is, the core idea in 60 seconds, install options, three common tasks, and a full documentation map.

**architecture/**
- `overview.md` — subsystem diagram, runtime data flow, and the adapter index-numbering convention.
- `switch.md` — how `SingleSwitch` selects adapters via attention.
- `token-exchange.md` — the KV-cache-safe control mechanism.
- `lora.md` — `SwitchedLoRALinear` and per-token weight application.
- `composer.md` — compose pipeline and CLI reference.
- `hf-backend.md` / `vllm-backend.md` — backend specifics and known limitations.
- `configuration.md` — full `GraniteSwitchConfig` reference.

**workflows/**
- `compose-a-model.md`, `inference.md`, `development.md`.

**domain/**
- `concepts.md` (glossary), `supported-models.md`.

## Other changes
- `AGENTS.md` (new) and `CLAUDE.md` now reference the OpenWiki as the starting point for docs.

## Notes
- Docs cite source files/paths throughout for verification.
- Flagged that the existing `GraniteSwitchConfig` example in `CLAUDE.md` is stale (references removed `hiding_groups`/`control_dims` from before the token-exchange rewrite).
