### PR TITLE
audio: splice full transcript; reject oversized requests via context

### DIFF
--- a/docs/AUDIO.md
+++ b/docs/AUDIO.md
@@ -70,10 +70,12 @@ editing that file directly — no re-compose and no patched package:
 
 ### Long audio & multiple clips
 
-The transcript token budget is derived from the **served context window**, not a
-fixed cap. Per request, the audio may occupy roughly
-`max_model_len − asr_generation_reserve_tokens − prompt_tokens`, split across the
-request's clips. Relevant config fields (all optional, sensible defaults):
+The transcript is spliced into the prompt as ordinary text tokens — it is **not**
+truncated to fit. A request behaves exactly like a long text request: if the
+prompt plus the transcript(s) leaves no room for the answer within the served
+`max_model_len`, vLLM rejects it with its standard prompt-length error (HTTP 400).
+Shorten the audio or serve with a larger `--max-model-len`. Relevant config fields
+(all optional, sensible defaults):
 
 - `asr_max_audio_clips` (default `32`) — how many audio clips one request may
   carry; each is spliced at its own `<|audio|>` marker. `--limit-mm-per-prompt`
@@ -81,8 +83,6 @@ request's clips. Relevant config fields (all optional, sensible defaults):
   Clips cost no extra KV (transcripts are ordinary text tokens bounded by the
   context); the ceiling guards against one request triggering an unbounded number
   of synchronous transcriptions.
-- `asr_generation_reserve_tokens` (default `8192`) — context held back for the
-  generated answer (and prompt overhead) when sizing the transcript budget.
 
 **Long single clips** are handled two ways, selected by `asr_self_chunks`:
 

--- a/src/granite_switch/composer/compose_granite_switch.py
+++ b/src/granite_switch/composer/compose_granite_switch.py
@@ -614,13 +614,6 @@ Examples:
              "--enable-audio.",
     )
     parser.add_argument(
-        "--asr-generation-reserve-tokens",
-        type=int,
-        default=None,
-        help="Context tokens held back for the generated answer when sizing the "
-             "per-clip transcript budget (default 8192). Implies --enable-audio.",
-    )
-    parser.add_argument(
         "--asr-self-chunks",
         dest="asr_self_chunks",
         action="store_true",
@@ -862,7 +855,6 @@ def build():
         or args.asr_pipeline_kwargs is not None
         or args.asr_generate_kwargs is not None
         or args.asr_max_audio_clips is not None
-        or args.asr_generation_reserve_tokens is not None
         or args.asr_self_chunks is not None
         or args.asr_chunk_length_s is not None
         or args.asr_chunk_overlap_s is not None
@@ -952,10 +944,6 @@ def build():
         # config keeps the constructor defaults otherwise.
         if args.asr_max_audio_clips is not None:
             model.config.asr_max_audio_clips = args.asr_max_audio_clips
-        if args.asr_generation_reserve_tokens is not None:
-            model.config.asr_generation_reserve_tokens = (
-                args.asr_generation_reserve_tokens
-            )
         if args.asr_self_chunks is not None:
             model.config.asr_self_chunks = args.asr_self_chunks
         if args.asr_chunk_length_s is not None:

--- a/src/granite_switch/config.py
+++ b/src/granite_switch/config.py
@@ -71,13 +71,6 @@ class GraniteSwitchConfig(GraniteMoeHybridConfig):
                 against one request triggering an unbounded number of synchronous
                 ASR transcriptions, and bounds the startup profiling pass. Default:
                 32.
-            asr_generation_reserve_tokens (int): Tokens held back from the context
-                window for the model's generated answer (and prompt overhead) when
-                computing how many transcript tokens the audio may occupy. The
-                per-request audio budget is roughly
-                ``max_model_len - asr_generation_reserve_tokens - prompt_tokens``,
-                split across the request's clips. Replaces the old fixed 2048-token
-                transcript cap with a context-derived one. Default: 8192.
             asr_chunk_length_s (float): Window length (seconds) our own long-audio
                 chunker splits a clip into before transcribing each window. Only
                 used for backends that do not self-chunk (see asr_self_chunks); the
@@ -119,7 +112,6 @@ class GraniteSwitchConfig(GraniteMoeHybridConfig):
         asr_pipeline_kwargs: dict | None = None,
         asr_generate_kwargs: dict | None = None,
         asr_max_audio_clips: int = 32,
-        asr_generation_reserve_tokens: int = 8192,
         asr_chunk_length_s: float = 30.0,
         asr_chunk_overlap_s: float = 5.0,
         asr_self_chunks: bool = True,
@@ -215,18 +207,13 @@ class GraniteSwitchConfig(GraniteMoeHybridConfig):
         # and default decode kwargs (applied per call, per-request overridable).
         self.asr_pipeline_kwargs = asr_pipeline_kwargs
         self.asr_generate_kwargs = asr_generate_kwargs
-        # Long-audio / multi-clip preprocessing. The transcript token budget is
-        # derived from the context window at runtime (max_model_len minus the
-        # generation reserve, split across clips) rather than a fixed cap; the
-        # chunker settings only apply to backends that do not self-chunk.
+        # Long-audio / multi-clip preprocessing. The transcript is spliced into
+        # the prompt as ordinary text tokens; a clip that makes the prompt exceed
+        # the context is rejected by vLLM's standard length check (no truncation).
+        # The chunker settings only apply to backends that do not self-chunk.
         if asr_max_audio_clips < 1:
             raise ValueError(
                 f"asr_max_audio_clips must be >= 1, got {asr_max_audio_clips}"
-            )
-        if asr_generation_reserve_tokens < 0:
-            raise ValueError(
-                f"asr_generation_reserve_tokens must be >= 0, got "
-                f"{asr_generation_reserve_tokens}"
             )
         if asr_chunk_overlap_s >= asr_chunk_length_s:
             raise ValueError(
@@ -234,7 +221,6 @@ class GraniteSwitchConfig(GraniteMoeHybridConfig):
                 f"asr_chunk_length_s ({asr_chunk_length_s})"
             )
         self.asr_max_audio_clips = asr_max_audio_clips
-        self.asr_generation_reserve_tokens = asr_generation_reserve_tokens
         self.asr_chunk_length_s = asr_chunk_length_s
         self.asr_chunk_overlap_s = asr_chunk_overlap_s
         self.asr_self_chunks = asr_self_chunks

--- a/src/granite_switch/vllm/audio/asr.py
+++ b/src/granite_switch/vllm/audio/asr.py
@@ -240,34 +240,6 @@ def resolve_generate_kwargs(
     return merged
 
 
-def audio_token_budget(
-    context_len: int,
-    reserve_tokens: int,
-    num_clips: int,
-    prompt_tokens: int = 0,
-) -> int:
-    """Max transcript tokens allowed per audio clip, derived from the context.
-
-    Replaces the old fixed 2048-token cap. The audio in a request may occupy the
-    context window minus what is held back for the generated answer (and any
-    prompt text already present), split evenly across the request's clips::
-
-        (context_len - reserve_tokens - prompt_tokens) // num_clips
-
-    Two call sites, both vLLM-free so this is unit-testable on CPU:
-      * startup profiling knows only ``context_len`` (seq_len) and the clip count
-        (``prompt_tokens`` defaults to 0), giving the worst-case per-clip bound;
-      * at request time the real prompt length is subtracted too, so the actual
-        transcript is always <= what profiling reserved.
-
-    Floored at 1 so every clip contributes at least one placeholder token (vLLM
-    rejects a multimodal item with zero placeholders).
-    """
-    clips = max(1, num_clips)
-    available = context_len - reserve_tokens - prompt_tokens
-    return max(1, available // clips)
-
-
 def _freeze(value: Any) -> Any:
     """Recursively convert dicts/lists into a hashable, order-stable form."""
     if isinstance(value, Mapping):

--- a/src/granite_switch/vllm/audio/processor.py
+++ b/src/granite_switch/vllm/audio/processor.py
@@ -51,7 +51,6 @@ from vllm.multimodal.processing import (
 from .asr import (
     DEFAULT_ALLOWED_REQUEST_GENERATE_KEYS,
     DEFAULT_ASR_MODEL_ID,
-    audio_token_budget,
     get_transcriber,
     resolve_generate_kwargs,
 )
@@ -94,16 +93,13 @@ class GraniteSwitchASRProcessingInfo(BaseProcessingInfo):
     ) -> Optional[Mapping[str, int]]:
         if not self._asr_enabled():
             return {}
-        # Per-clip transcript bound derived from the context window vLLM passes in
-        # (seq_len), minus the generation reserve, split across the max clip count.
-        # This is the worst case for profiling; the runtime budget also subtracts
-        # the prompt length, so it is never larger than this.
+        # Worst-case transcript positions one clip can occupy, used only to size
+        # the encoder cache and profiling pass — NOT to bound requests. A clip
+        # cannot transcribe to more than the whole context (a longer prompt is
+        # rejected by vLLM's standard length check), so the per-clip share of the
+        # context window is the honest upper bound. vLLM calls this with count=1.
         count = mm_counts.get("audio", 1) or 1
-        return {
-            "audio": audio_token_budget(
-                seq_len, self._asr_generation_reserve_tokens(), count
-            )
-        }
+        return {"audio": max(1, seq_len // count)}
 
     def get_data_parser(self) -> MultiModalDataParser:
         # Resample incoming audio to the ASR sample rate.
@@ -130,10 +126,6 @@ class GraniteSwitchASRProcessingInfo(BaseProcessingInfo):
     def _asr_max_audio_clips(self) -> int:
         cfg = self.get_hf_config()
         return int(getattr(cfg, "asr_max_audio_clips", 32) or 32)
-
-    def _asr_generation_reserve_tokens(self) -> int:
-        cfg = self.get_hf_config()
-        return int(getattr(cfg, "asr_generation_reserve_tokens", 8192) or 0)
 
     def _asr_self_chunks(self) -> bool:
         cfg = self.get_hf_config()
@@ -192,9 +184,12 @@ class GraniteSwitchASRMultiModalProcessor(
         self,
         audio,
         generate_kwargs: Optional[Mapping[str, object]] = None,
-        budget: Optional[int] = None,
     ) -> list[int]:
-        """Transcribe one audio item to a list of token ids (capped at ``budget``).
+        """Transcribe one audio item to a list of token ids (full transcript).
+
+        The transcript is spliced into the prompt as ordinary text tokens; it is
+        never truncated here. A clip whose transcript makes the prompt exceed the
+        context is rejected by vLLM's standard prompt-length check.
 
         Long audio is handled by the backend itself (Whisper) or by our
         encoder-agnostic chunker, per the checkpoint's ``asr_self_chunks`` flag.
@@ -214,10 +209,7 @@ class GraniteSwitchASRMultiModalProcessor(
             chunk_overlap_s=self.info._asr_chunk_overlap_s(),
         )
         tokenizer = self.info.get_tokenizer()
-        ids = tokenizer.encode(text, add_special_tokens=False)
-        # Cap to the per-clip transcript budget so the spliced sequence fits the
-        # context window vLLM profiled for.
-        return ids[:budget] if budget is not None else ids
+        return tokenizer.encode(text, add_special_tokens=False)
 
     def _call_hf_processor(
         self,
@@ -244,18 +236,10 @@ class GraniteSwitchASRMultiModalProcessor(
 
         input_ids = tokenizer.encode(prompt, add_special_tokens=False)
 
-        # Per-clip transcript budget: the served context minus the generation
-        # reserve and the prompt already present, split across this request's
-        # clips. Derived from the context window rather than a fixed cap.
-        budget = audio_token_budget(
-            self.info._max_model_len(),
-            self.info._asr_generation_reserve_tokens(),
-            len(audios),
-            prompt_tokens=len(input_ids),
-        )
-
         # Transcribe each audio to token ids; concatenate flat with per-item sizes.
-        per_item_ids = [self._transcribe(a, generate_kwargs, budget) for a in audios]
+        # Transcripts are spliced in full — an oversized request is rejected by
+        # vLLM's prompt-length check, not silently truncated here.
+        per_item_ids = [self._transcribe(a, generate_kwargs) for a in audios]
         sizes = [len(ids) for ids in per_item_ids]
         flat_ids = [tid for ids in per_item_ids for tid in ids]
 

--- a/tests/unit/test_asr.py
+++ b/tests/unit/test_asr.py
@@ -113,27 +113,6 @@ class TestTranscriber:
         assert t._pipeline is sentinel
 
 
-class TestAudioTokenBudget:
-    def test_single_clip_uses_context_minus_reserve(self):
-        assert asr.audio_token_budget(131072, 8192, 1) == 131072 - 8192
-
-    def test_split_across_clips(self):
-        # (131072 - 8192) // 4
-        assert asr.audio_token_budget(131072, 8192, 4) == (131072 - 8192) // 4
-
-    def test_prompt_tokens_subtracted(self):
-        assert asr.audio_token_budget(8192, 4096, 2, prompt_tokens=1000) == (
-            (8192 - 4096 - 1000) // 2
-        )
-
-    def test_floors_at_one_when_no_room(self):
-        # Reserve exceeds context -> still at least one placeholder per clip.
-        assert asr.audio_token_budget(100, 200, 1) == 1
-
-    def test_zero_clip_count_treated_as_one(self):
-        assert asr.audio_token_budget(1000, 0, 0) == 1000
-
-
 class TestChunkedTranscribe:
     """self_chunks=False routes through the split/transcribe/merge chunker."""
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -113,7 +113,6 @@ class TestAudioConfig:
     def test_longaudio_defaults(self):
         cfg = GraniteSwitchConfig(num_adapters=0)
         assert cfg.asr_max_audio_clips == 32
-        assert cfg.asr_generation_reserve_tokens == 8192
         assert cfg.asr_chunk_length_s == 30.0
         assert cfg.asr_chunk_overlap_s == 5.0
         assert cfg.asr_self_chunks is True
@@ -123,7 +122,6 @@ class TestAudioConfig:
             num_adapters=0,
             asr_enabled=True,
             asr_max_audio_clips=4,
-            asr_generation_reserve_tokens=4096,
             asr_chunk_length_s=20.0,
             asr_chunk_overlap_s=3.0,
             asr_self_chunks=False,
@@ -131,7 +129,6 @@ class TestAudioConfig:
         cfg.save_pretrained(tmp_path)
         loaded = GraniteSwitchConfig.from_pretrained(tmp_path)
         assert loaded.asr_max_audio_clips == 4
-        assert loaded.asr_generation_reserve_tokens == 4096
         assert loaded.asr_chunk_length_s == 20.0
         assert loaded.asr_chunk_overlap_s == 3.0
         assert loaded.asr_self_chunks is False

--- a/tests/vllm/test_audio_processor.py
+++ b/tests/vllm/test_audio_processor.py
@@ -75,13 +75,15 @@ class TestProcessingInfoGating:
         assert info3.get_supported_mm_limits() == {"audio": 3}
 
     def test_max_tokens_per_item_is_context_derived(self):
-        # Budget = (seq_len - generation_reserve) // clip_count (default reserve 8192).
+        # Profiling/encoder-cache hint = per-clip share of the context (seq_len //
+        # clip_count), the worst case one clip can occupy. Not a request bound —
+        # an oversized transcript is rejected by vLLM's prompt-length check.
         info = _make_info(asr_enabled=True)
         assert info.get_mm_max_tokens_per_item(20000, {"audio": 1}) == {
-            "audio": 20000 - 8192
+            "audio": 20000
         }
         assert info.get_mm_max_tokens_per_item(20000, {"audio": 4}) == {
-            "audio": (20000 - 8192) // 4
+            "audio": 20000 // 4
         }
 
 
@@ -114,7 +116,6 @@ class TestProcessingInfoAsrAccessors:
     def test_longaudio_accessor_defaults(self):
         info = _make_info(asr_enabled=True)
         assert info._asr_max_audio_clips() == 32
-        assert info._asr_generation_reserve_tokens() == 8192
         assert info._asr_self_chunks() is True
         assert info._asr_chunk_length_s() == 30.0
         assert info._asr_chunk_overlap_s() == 5.0
@@ -123,13 +124,11 @@ class TestProcessingInfoAsrAccessors:
         info = _make_info(
             asr_enabled=True,
             asr_max_audio_clips=2,
-            asr_generation_reserve_tokens=4096,
             asr_self_chunks=False,
             asr_chunk_length_s=20.0,
             asr_chunk_overlap_s=3.0,
         )
         assert info._asr_max_audio_clips() == 2
-        assert info._asr_generation_reserve_tokens() == 4096
         assert info._asr_self_chunks() is False
         assert info._asr_chunk_length_s() == 20.0
         assert info._asr_chunk_overlap_s() == 3.0
@@ -270,7 +269,7 @@ class TestCallHfProcessorMerge:
 
 
 class TestMultiClipAndBudget:
-    """#1 (multiple clips) + #2 (context-derived per-clip token budget)."""
+    """Multiple clips, each transcribed in full and spliced at its marker."""
 
     def test_two_clips_produce_two_transcripts(self, monkeypatch):
         capture = {}
@@ -291,16 +290,15 @@ class TestMultiClipAndBudget:
         assert bf["audio_num_tokens"].tolist() == [3, 3]
         assert len(bf["audio_token_ids"]) == 6
 
-    def test_transcribe_truncates_to_budget(self, monkeypatch):
+    def test_transcribe_returns_full_transcript(self, monkeypatch):
+        # The transcript is never truncated here — it is spliced in full and an
+        # oversized prompt is rejected downstream by vLLM's length check.
         capture = {}
         info = _make_info(asr_enabled=True, asr_model_id="w")
         proc = _make_processor(info, monkeypatch, capture)
-        # Override tokenizer to emit 5 ids so the budget cut is visible.
         info.get_tokenizer = lambda: SimpleNamespace(
             encode=lambda text, add_special_tokens=False: [1, 2, 3, 4, 5]
         )
-        assert proc._transcribe(np.zeros(1600, dtype=np.float32), {}, budget=2) == [1, 2]
-        # No budget -> untruncated.
         assert proc._transcribe(np.zeros(1600, dtype=np.float32), {}) == [1, 2, 3, 4, 5]
 
     def test_self_chunks_and_chunk_params_forwarded(self, monkeypatch):


### PR DESCRIPTION
…check (#45)

The audio cascade truncated the transcript to a context-derived per-clip budget (asr_generation_reserve_tokens held back for the answer). When that reserve met or exceeded the served max_model_len, the budget floored to 1 token: the model saw no question and refused, with no error (#45).

Rather than patch the truncation math, remove it. The transcript is now spliced into the prompt in full, as ordinary text tokens. A request whose prompt + transcript(s) can't leave room for the answer within max_model_len is rejected by vLLM's standard prompt-length check (HTTP 400) — the same loud failure text-only requests already get, instead of a silent 1-token transcript. This also makes audio behave identically to long text.

Details:
- Remove asr_generation_reserve_tokens entirely (config field + validation, compose CLI flag, processor accessor). It only existed to size the old truncation budget.
- Drop the budget param / ids[:budget] truncation in the processor; splice the full transcript.
- get_mm_max_tokens_per_item now reports max(1, seq_len // count) — the honest worst-case transcript positions one clip can occupy. This still sizes vLLM's encoder cache correctly (embed_multimodal emits one row per transcript token); it is a profiling hint, not a request bound.
- Remove the now-dead audio_token_budget helper and its tests.

Tests updated; docs/AUDIO.md rewritten to describe reject-not-truncate.